### PR TITLE
Migrate to JUnit 5

### DIFF
--- a/bot/admin/kotlin-compiler/client/pom.xml
+++ b/bot/admin/kotlin-compiler/client/pom.xml
@@ -48,12 +48,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bot/admin/kotlin-compiler/client/src/test/kotlin/fr/vsct/tock/bot/admin/kotlin/compiler/client/KotlinClientIntegrationTest.kt
+++ b/bot/admin/kotlin-compiler/client/src/test/kotlin/fr/vsct/tock/bot/admin/kotlin/compiler/client/KotlinClientIntegrationTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.bot.admin.kotlin.compiler.client
 
 import fr.vsct.tock.bot.admin.kotlin.compiler.KotlinFile
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  *

--- a/bot/admin/kotlin-compiler/core/pom.xml
+++ b/bot/admin/kotlin-compiler/core/pom.xml
@@ -48,12 +48,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bot/admin/kotlin-compiler/core/src/test/kotlin/fr/vsct/tock/bot/admin/kotlin/compiler/KotlinCompilerTest.kt
+++ b/bot/admin/kotlin-compiler/core/src/test/kotlin/fr/vsct/tock/bot/admin/kotlin/compiler/KotlinCompilerTest.kt
@@ -16,8 +16,8 @@
 
 package fr.vsct.tock.bot.admin.kotlin.compiler
 
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -28,7 +28,7 @@ import kotlin.test.assertTrue
 class KotlinCompilerTest {
 
     companion object {
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun beforeClass() {
             KotlinCompiler.init(listOf("target/test-classes/"))
@@ -38,8 +38,8 @@ class KotlinCompilerTest {
     }
 
     class CompilationResultClassLoader(
-            val className: String,
-            val bytes: ByteArray
+        val className: String,
+        val bytes: ByteArray
     ) : ClassLoader(CompilationResultClassLoader::class.java.classLoader) {
 
         @Override
@@ -58,63 +58,63 @@ class KotlinCompilerTest {
         val expectedError = try {
             Runtime::class.java.getMethod("version").invoke(null)
             listOf(
-                    CompileError(
-                            TextInterval(
-                                    TextPosition(2, 20),
-                                    TextPosition(2, 27)
-                            ),
-                            "Unresolved reference: println",
-                            Severity.ERROR,
-                            "ERROR"
+                CompileError(
+                    TextInterval(
+                        TextPosition(2, 20),
+                        TextPosition(2, 27)
                     ),
-                    CompileError(
-                            TextInterval(
-                                    TextPosition(2, 34),
-                                    TextPosition(2, 35)
-                            ),
-                            "Expecting '\"'",
-                            Severity.ERROR,
-                            "red_wavy_line"
+                    "Unresolved reference: println",
+                    Severity.ERROR,
+                    "ERROR"
+                ),
+                CompileError(
+                    TextInterval(
+                        TextPosition(2, 34),
+                        TextPosition(2, 35)
                     ),
-                    CompileError(
-                            TextInterval(
-                                    TextPosition(line = 2, ch = 34),
-                                    TextPosition(line = 2, ch = 35)
-                            ),
-                            "Expecting ')'",
-                            Severity.ERROR,
-                            "red_wavy_line"
-                    )
+                    "Expecting '\"'",
+                    Severity.ERROR,
+                    "red_wavy_line"
+                ),
+                CompileError(
+                    TextInterval(
+                        TextPosition(line = 2, ch = 34),
+                        TextPosition(line = 2, ch = 35)
+                    ),
+                    "Expecting ')'",
+                    Severity.ERROR,
+                    "red_wavy_line"
+                )
             )
         } catch (e: Throwable) {
             //java 8
             listOf(
-                    CompileError(
-                            TextInterval(
-                                    TextPosition(2, 34),
-                                    TextPosition(2, 35)
-                            ),
-                            "Expecting '\"'",
-                            Severity.ERROR,
-                            "red_wavy_line"
+                CompileError(
+                    TextInterval(
+                        TextPosition(2, 34),
+                        TextPosition(2, 35)
                     ),
-                    CompileError(
-                            TextInterval(
-                                    TextPosition(2, 34),
-                                    TextPosition(2, 35)
-                            ),
-                            "Expecting ')'",
-                            Severity.ERROR,
-                            "red_wavy_line"
-                    )
+                    "Expecting '\"'",
+                    Severity.ERROR,
+                    "red_wavy_line"
+                ),
+                CompileError(
+                    TextInterval(
+                        TextPosition(2, 34),
+                        TextPosition(2, 35)
+                    ),
+                    "Expecting ')'",
+                    Severity.ERROR,
+                    "red_wavy_line"
+                )
             )
         }
 
 
         val erroneousSourceCode = mapOf(
-                "ClassToBeCompiled.kt"
-                        to
-                        """
+            "ClassToBeCompiled.kt"
+                    to
+                    """
                 fun main(args: Array<String>) {
                     println("Hello)
                 }"""
@@ -123,16 +123,16 @@ class KotlinCompilerTest {
         val errors = KotlinCompiler.getErrors(erroneousSourceCode)
         assertEquals(1, errors.size)
         assertEquals(
-                expectedError, errors["ClassToBeCompiled.kt"]
+            expectedError, errors["ClassToBeCompiled.kt"]
         )
     }
 
     @Test
     fun `simple compilation and execution succeed`() {
         val sourceCode = mapOf(
-                "ClassToBeCompiled.kt"
-                        to
-                        """
+            "ClassToBeCompiled.kt"
+                    to
+                    """
                 fun main(args: Array<String>) {
                     fr.vsct.tock.bot.admin.kotlin.compiler.KotlinCompilerTest.mark = true
                 }"""
@@ -141,7 +141,7 @@ class KotlinCompilerTest {
         assertEquals(emptyList(), KotlinCompiler.getErrors(sourceCode)["ClassToBeCompiled.kt"])
         val result = KotlinCompiler.compileCorrectFiles(sourceCode, "ClassToBeCompiled.kt", true)
         val compiledClassLoader =
-                CompilationResultClassLoader("ClassToBeCompiledKt", result.files["ClassToBeCompiledKt.class"]!!)
+            CompilationResultClassLoader("ClassToBeCompiledKt", result.files["ClassToBeCompiledKt.class"]!!)
         val c = compiledClassLoader.loadClass("ClassToBeCompiledKt")
         c.declaredMethods[0].invoke(null, arrayOf<String>())
         assertTrue(mark)
@@ -157,9 +157,9 @@ class KotlinCompilerTest {
             return
         }
         val sourceCode = mapOf(
-                "ClassToBeCompiled.kt"
-                        to
-                        """
+            "ClassToBeCompiled.kt"
+                    to
+                    """
                 fun main(args: Array<String>) {
                     fr.vsct.tock.duckling.client.DucklingEntityEvaluatorProvider()
                 }"""

--- a/bot/admin/server/pom.xml
+++ b/bot/admin/server/pom.xml
@@ -56,12 +56,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/admin/server/src/test/kotlin/fr/vsct/tock/bot/admin/I18nCsvCodecTest.kt
+++ b/bot/admin/server/src/test/kotlin/fr/vsct/tock/bot/admin/I18nCsvCodecTest.kt
@@ -31,7 +31,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.litote.kmongo.toId
 import java.util.Locale.FRENCH
 import kotlin.test.assertEquals

--- a/bot/admin/test/core/pom.xml
+++ b/bot/admin/test/core/pom.xml
@@ -39,13 +39,18 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bot/admin/test/core/src/test/kotlin/fr/vsct/tock/bot/admin/test/ClientMessageConverterTest.kt
+++ b/bot/admin/test/core/src/test/kotlin/fr/vsct/tock/bot/admin/test/ClientMessageConverterTest.kt
@@ -20,7 +20,7 @@ import fr.vsct.tock.bot.connector.rest.client.model.ClientAttachment
 import fr.vsct.tock.bot.connector.rest.client.model.ClientAttachmentType
 import fr.vsct.tock.bot.engine.action.SendAttachment
 import fr.vsct.tock.bot.engine.message.Attachment
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -33,8 +33,8 @@ class ClientMessageConverterTest {
         val a = Attachment("a", SendAttachment.AttachmentType.file, 200)
 
         assertEquals(
-                ClientAttachment("a", ClientAttachmentType.file),
-                a.toClientMessage()
+            ClientAttachment("a", ClientAttachmentType.file),
+            a.toClientMessage()
         )
     }
 }

--- a/bot/admin/test/xray/pom.xml
+++ b/bot/admin/test/xray/pom.xml
@@ -43,13 +43,18 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bot/connector-alexa/pom.xml
+++ b/bot/connector-alexa/pom.xml
@@ -85,12 +85,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/connector-alexa/src/test/kotlin/fr/vsct/tock/bot/connector/alexa/AlexaMessageTest.kt
+++ b/bot/connector-alexa/src/test/kotlin/fr/vsct/tock/bot/connector/alexa/AlexaMessageTest.kt
@@ -21,7 +21,7 @@ import com.amazon.speech.ui.StandardCard
 import fr.vsct.tock.bot.engine.action.SendAttachment
 import fr.vsct.tock.bot.engine.message.Attachment
 import fr.vsct.tock.bot.engine.message.SentenceElement
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/bot/connector-ga/pom.xml
+++ b/bot/connector-ga/pom.xml
@@ -53,12 +53,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/ExtensionsTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/ExtensionsTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.bot.connector.ga
 
 import fr.vsct.tock.translator.TextAndVoiceTranslatedString
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/GAConnectorTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/GAConnectorTest.kt
@@ -27,10 +27,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.vertx.core.http.HttpServerResponse
 import io.vertx.ext.web.RoutingContext
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  *
@@ -43,7 +42,7 @@ class GAConnectorTest {
     val context: RoutingContext = mockk(relaxed = true)
     val response: HttpServerResponse = mockk(relaxed = true)
 
-    @Before
+    @BeforeEach
     fun before() {
         every { context.response() } returns response
     }
@@ -61,7 +60,11 @@ class GAConnectorTest {
             )
         }
 
-        connector.handleRequest(controller, context, Resources.toString(resource("/request-with-permission.json"), Charsets.UTF_8))
+        connector.handleRequest(
+            controller,
+            context,
+            Resources.toString(resource("/request-with-permission.json"), Charsets.UTF_8)
+        )
 
         assertEquals("Pierre", userPreferences.firstName)
         assertEquals("Totor", userPreferences.lastName)

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/GAResponseConnectorMessageTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/GAResponseConnectorMessageTest.kt
@@ -20,7 +20,7 @@ import fr.vsct.tock.bot.connector.ga.model.response.GAFinalResponse
 import fr.vsct.tock.bot.connector.ga.model.response.GAItem
 import fr.vsct.tock.bot.connector.ga.model.response.GARichResponse
 import fr.vsct.tock.bot.connector.ga.model.response.GASimpleResponse
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -31,16 +31,16 @@ class GAResponseConnectorMessageTest {
     @Test
     fun toSentenceElement_shouldRenderSimpleText() {
         val r = GAResponseConnectorMessage(
-                finalResponse =
-                GAFinalResponse(
-                        GARichResponse(
-                                listOf(
-                                        GAItem(
-                                                GASimpleResponse("ok computer")
-                                        )
-                                )
+            finalResponse =
+            GAFinalResponse(
+                GARichResponse(
+                    listOf(
+                        GAItem(
+                            GASimpleResponse("ok computer")
                         )
+                    )
                 )
+            )
         )
         val e = r.toSentenceElement()
         assertEquals(mapOf("textToSpeech" to "ok computer"), e!!.texts)

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/RoutingContextHolderTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/RoutingContextHolderTest.kt
@@ -24,16 +24,14 @@ import fr.vsct.tock.bot.connector.ga.model.request.GASurface
 import fr.vsct.tock.bot.connector.ga.model.request.GAUser
 import fr.vsct.tock.bot.engine.BotBus
 import fr.vsct.tock.bot.engine.ConnectorController
-import fr.vsct.tock.bot.engine.I18nTranslator
 import fr.vsct.tock.bot.engine.action.SendSentence
 import fr.vsct.tock.bot.engine.user.PlayerId
 import fr.vsct.tock.bot.engine.user.PlayerType
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.spyk
 import io.vertx.ext.web.RoutingContext
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -45,7 +43,7 @@ class RoutingContextHolderTest {
     private val context: RoutingContext = mockk(relaxed = true)
     private val controller: ConnectorController = mockk(relaxed = true)
 
-    @Before
+    @BeforeEach
     fun init() {
         every { bus.translate(any<CharSequence>()) } answers { firstArg() }
         every { bus.translateAndReturnBlankAsNull(any()) } answers { firstArg() }

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/WebhookActionConverterTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/WebhookActionConverterTest.kt
@@ -24,7 +24,7 @@ import fr.vsct.tock.bot.engine.stt.SttListener
 import fr.vsct.tock.bot.engine.stt.SttService
 import fr.vsct.tock.shared.jackson.mapper
 import fr.vsct.tock.shared.resource
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/model/request/GARequestDeserializerTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/model/request/GARequestDeserializerTest.kt
@@ -19,7 +19,7 @@ package fr.vsct.tock.bot.connector.ga.model.request
 import com.fasterxml.jackson.module.kotlin.readValue
 import fr.vsct.tock.shared.jackson.mapper
 import fr.vsct.tock.shared.resource
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
@@ -54,16 +54,54 @@ class GARequestDeserializerTest {
         val json = resource("/request-with-location.json")
         val request: GARequest = mapper.readValue(json)
         assertEquals(
-                GARequest(
-                        user = GAUser(userId = "a", profile = null, accessToken = null, permissions = null, locale = "en-US"),
-                        device = GADevice(location = GALocation(coordinates = GALatLng(latitude = 37.4219806, longitude = -122.0841979), formattedAddress = null, zipCode = null, city = null, postalAddress = null, name = null, phoneNumber = null, notes = null)), surface = GASurface(
-                        capabilities = listOf(GACapability(name = "actions.capability.AUDIO_OUTPUT"), GACapability(name = "actions.capability.SCREEN_OUTPUT"))), conversation = GAConversation(conversationId = "1505388822587", type = GAConversationType.NEW, conversationToken = null),
-                        inputs = listOf(GAInput(rawInputs = listOf(GARawInput(createTime = null, inputType = GAInputType.VOICE, query = "yes")),
-                                intent = "actions.intent.PERMISSION", arguments =
+            GARequest(
+                user = GAUser(userId = "a", profile = null, accessToken = null, permissions = null, locale = "en-US"),
+                device = GADevice(
+                    location = GALocation(
+                        coordinates = GALatLng(
+                            latitude = 37.4219806,
+                            longitude = -122.0841979
+                        ),
+                        formattedAddress = null,
+                        zipCode = null,
+                        city = null,
+                        postalAddress = null,
+                        name = null,
+                        phoneNumber = null,
+                        notes = null
+                    )
+                ),
+                surface = GASurface(
+                    capabilities = listOf(
+                        GACapability(name = "actions.capability.AUDIO_OUTPUT"),
+                        GACapability(name = "actions.capability.SCREEN_OUTPUT")
+                    )
+                ),
+                conversation = GAConversation(
+                    conversationId = "1505388822587",
+                    type = GAConversationType.NEW,
+                    conversationToken = null
+                ),
+                inputs = listOf(
+                    GAInput(
+                        rawInputs = listOf(GARawInput(createTime = null, inputType = GAInputType.VOICE, query = "yes")),
+                        intent = "actions.intent.PERMISSION", arguments =
                         listOf(
-                                GAArgument
-                                (name = "PERMISSION", rawText = null, boolValue = null, textValue = "true", datetimeValue = null, extension = null)))), isInSandbox = true),
-                request
+                            GAArgument
+                                (
+                                name = "PERMISSION",
+                                rawText = null,
+                                boolValue = null,
+                                textValue = "true",
+                                datetimeValue = null,
+                                extension = null
+                            )
+                        )
+                    )
+                ),
+                isInSandbox = true
+            ),
+            request
         )
     }
 

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/model/request/GARequestTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/model/request/GARequestTest.kt
@@ -18,8 +18,8 @@ package fr.vsct.tock.bot.connector.ga.model.request
 
 import fr.vsct.tock.bot.connector.ga.model.request.GACapability.Companion.AUDIO_OUTPUT
 import fr.vsct.tock.translator.UserInterfaceType
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 /**
  *
@@ -29,11 +29,12 @@ class GARequestTest {
     @Test
     fun getEventState_shouldReturnsVoiceAssistant_whenOnlyAudioCapability() {
         val request = GARequest(
-                GAUser("a"),
-                GADevice(),
-                GASurface(listOf(GACapability(AUDIO_OUTPUT))),
-                GAConversation(),
-                emptyList())
+            GAUser("a"),
+            GADevice(),
+            GASurface(listOf(GACapability(AUDIO_OUTPUT))),
+            GAConversation(),
+            emptyList()
+        )
 
         assertEquals(UserInterfaceType.voiceAssistant, request.getEventState().userInterface)
     }

--- a/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/model/response/GAOptionValueSpecTest.kt
+++ b/bot/connector-ga/src/test/kotlin/fr/vsct/tock/bot/connector/ga/model/response/GAOptionValueSpecTest.kt
@@ -18,7 +18,7 @@ package fr.vsct.tock.bot.connector.ga.model.response
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import fr.vsct.tock.shared.jackson.mapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -29,33 +29,35 @@ class GAOptionValueSpecTest {
     @Test
     fun testSerializationAndDeserialization() {
         val option = GAOptionValueSpec(
-                carouselSelect =
-                GACarouselSelect(
-                        listOf(
-                                GACarouselItem(
-                                        GAOptionInfo(
-                                                "key1",
-                                                listOf("synonym1")
-                                        ),
-                                        "titre1",
-                                        "description1",
-                                        GAImage(
-                                                "https://aaa.com/test.png",
-                                                "Image with text")
-                                ),
-                                GACarouselItem(
-                                        GAOptionInfo(
-                                                "key2",
-                                                listOf("synonym2")
-                                        ),
-                                        "titre2",
-                                        "description2",
-                                        GAImage(
-                                                "https://aaa.com/test2.png",
-                                                "Image with text")
-                                )
+            carouselSelect =
+            GACarouselSelect(
+                listOf(
+                    GACarouselItem(
+                        GAOptionInfo(
+                            "key1",
+                            listOf("synonym1")
+                        ),
+                        "titre1",
+                        "description1",
+                        GAImage(
+                            "https://aaa.com/test.png",
+                            "Image with text"
                         )
+                    ),
+                    GACarouselItem(
+                        GAOptionInfo(
+                            "key2",
+                            listOf("synonym2")
+                        ),
+                        "titre2",
+                        "description2",
+                        GAImage(
+                            "https://aaa.com/test2.png",
+                            "Image with text"
+                        )
+                    )
                 )
+            )
         )
         val s = mapper.writeValueAsString(option)
         assertEquals(option, mapper.readValue<GAInputValueData>(s))

--- a/bot/connector-messenger/pom.xml
+++ b/bot/connector-messenger/pom.xml
@@ -48,12 +48,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/MessengerBuildersTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/MessengerBuildersTest.kt
@@ -30,8 +30,9 @@ import fr.vsct.tock.shared.sharedTestModule
 import fr.vsct.tock.shared.tockInternalInjector
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
 
 /**
@@ -41,7 +42,7 @@ class MessengerBuildersTest {
 
     val bus: BotBus = mockk(relaxed = true)
 
-    @Before
+    @BeforeEach
     fun before() {
         tockInternalInjector = KodeinInjector().apply {
             inject(Kodein {
@@ -54,35 +55,46 @@ class MessengerBuildersTest {
         every { bus.translate(allAny()) } answers { firstArg() ?: "" }
     }
 
-    @Test(expected = IllegalStateException::class)
+    @Test
     fun `listTemplate throws exception WHEN at least one element does not contain an image url AND list style is not compact`() {
-        listTemplate(bus.listElement("title"), bus.listElement("title2"))
+        assertThrows<IllegalStateException> {
+            listTemplate(bus.listElement("title"), bus.listElement("title2"))
+        }
     }
 
     @Test
     fun testImage() {
-        assertEquals(AttachmentMessage(
-                attachment = Attachment(type = image,
-                        payload = UrlPayload("http://test", null, true))
-        ), bus.image("http://test")
+        assertEquals(
+            AttachmentMessage(
+                attachment = Attachment(
+                    type = image,
+                    payload = UrlPayload("http://test", null, true)
+                )
+            ), bus.image("http://test")
         )
     }
 
     @Test
     fun testVideo() {
-        assertEquals(AttachmentMessage(
-                attachment = Attachment(type = video,
-                        payload = UrlPayload("http://test", null, true))
-        ), bus.video("http://test")
+        assertEquals(
+            AttachmentMessage(
+                attachment = Attachment(
+                    type = video,
+                    payload = UrlPayload("http://test", null, true)
+                )
+            ), bus.video("http://test")
         )
     }
 
     @Test
     fun testAudio() {
-        assertEquals(AttachmentMessage(
-                attachment = Attachment(type = audio,
-                        payload = UrlPayload("http://test", null, true))
-        ), bus.audio("http://test")
+        assertEquals(
+            AttachmentMessage(
+                attachment = Attachment(
+                    type = audio,
+                    payload = UrlPayload("http://test", null, true)
+                )
+            ), bus.audio("http://test")
         )
     }
 }

--- a/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/json/send/MessageRequestDeserializationTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/json/send/MessageRequestDeserializationTest.kt
@@ -18,9 +18,21 @@ package fr.vsct.tock.bot.connector.messenger.json.send
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import fr.vsct.tock.bot.connector.messenger.model.Recipient
-import fr.vsct.tock.bot.connector.messenger.model.send.*
+import fr.vsct.tock.bot.connector.messenger.model.send.Attachment
+import fr.vsct.tock.bot.connector.messenger.model.send.AttachmentMessage
+import fr.vsct.tock.bot.connector.messenger.model.send.AttachmentType
+import fr.vsct.tock.bot.connector.messenger.model.send.Element
+import fr.vsct.tock.bot.connector.messenger.model.send.GenericPayload
+import fr.vsct.tock.bot.connector.messenger.model.send.LocationQuickReply
+import fr.vsct.tock.bot.connector.messenger.model.send.MessageRequest
+import fr.vsct.tock.bot.connector.messenger.model.send.MessageTag
+import fr.vsct.tock.bot.connector.messenger.model.send.PostbackButton
+import fr.vsct.tock.bot.connector.messenger.model.send.QuickReply
+import fr.vsct.tock.bot.connector.messenger.model.send.TextMessage
+import fr.vsct.tock.bot.connector.messenger.model.send.TextQuickReply
+import fr.vsct.tock.bot.connector.messenger.model.send.UrlPayload
 import fr.vsct.tock.shared.jackson.mapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -31,33 +43,37 @@ class MessageRequestDeserializationTest {
     @Test
     fun testMessageRequestWithButtonDeserialization() {
         val m = MessageRequest(
-                Recipient("2"),
-                AttachmentMessage(
-                        Attachment(
-                                AttachmentType.template,
-                                GenericPayload(
-                                        listOf(
-                                                Element(
-                                                        "title",
-                                                        buttons = listOf(
-                                                                PostbackButton(
-                                                                        "payload",
-                                                                        "titleButton"
-                                                                )
-                                                        )
-                                                )
-                                        )
+            Recipient("2"),
+            AttachmentMessage(
+                Attachment(
+                    AttachmentType.template,
+                    GenericPayload(
+                        listOf(
+                            Element(
+                                "title",
+                                buttons = listOf(
+                                    PostbackButton(
+                                        "payload",
+                                        "titleButton"
+                                    )
                                 )
+                            )
                         )
+                    )
                 )
-        ,tag = MessageTag.FEATURE_FUNCTIONALITY_UPDATE)
+            )
+            , tag = MessageTag.FEATURE_FUNCTIONALITY_UPDATE
+        )
         val s = mapper.writeValueAsString(m)
         assertEquals(m, mapper.readValue<MessageRequest>(s))
     }
 
     @Test
     fun testMessageRequestWithUrlPayload() {
-        val m = MessageRequest(Recipient("2"), AttachmentMessage(Attachment(AttachmentType.image, UrlPayload("http://test/test.png", null, null))))
+        val m = MessageRequest(
+            Recipient("2"),
+            AttachmentMessage(Attachment(AttachmentType.image, UrlPayload("http://test/test.png", null, null)))
+        )
         val s = mapper.writeValueAsString(m)
         assertEquals(m, mapper.readValue<MessageRequest>(s))
     }
@@ -71,11 +87,11 @@ class MessageRequestDeserializationTest {
                 "      }"
         val output = mapper.readValue<QuickReply>(input)
         assertEquals(
-                TextQuickReply(
-                        "Green",
-                        "DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_GREEN"
-                ),
-                output
+            TextQuickReply(
+                "Green",
+                "DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_GREEN"
+            ),
+            output
         )
     }
 
@@ -86,8 +102,8 @@ class MessageRequestDeserializationTest {
                 "      }"
         val output = mapper.readValue<QuickReply>(input)
         assertEquals(
-                LocationQuickReply(),
-                output
+            LocationQuickReply(),
+            output
         )
     }
 
@@ -115,24 +131,24 @@ class MessageRequestDeserializationTest {
                 "}"
         val output = mapper.readValue<MessageRequest>(input)
         assertEquals(
-                MessageRequest(
-                        Recipient("USER_ID"),
-                        TextMessage(
-                                "Pick a color:",
-                                listOf(
-                                        TextQuickReply(
-                                                "Red",
-                                                "DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED"
-                                        ),
-                                        TextQuickReply(
-                                                "Green",
-                                                "DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_GREEN"
-                                        )
-                                )
+            MessageRequest(
+                Recipient("USER_ID"),
+                TextMessage(
+                    "Pick a color:",
+                    listOf(
+                        TextQuickReply(
+                            "Red",
+                            "DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED"
+                        ),
+                        TextQuickReply(
+                            "Green",
+                            "DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_GREEN"
                         )
+                    )
+                )
 
-                ),
-                output
+            ),
+            output
         )
 
         assertEquals(output, mapper.readValue(mapper.writeValueAsString(output)))

--- a/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/json/webhook/WebhookDeserializationTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/json/webhook/WebhookDeserializationTest.kt
@@ -19,18 +19,17 @@ package fr.vsct.tock.bot.connector.messenger.json.webhook
 import com.fasterxml.jackson.module.kotlin.readValue
 import fr.vsct.tock.bot.connector.messenger.model.Recipient
 import fr.vsct.tock.bot.connector.messenger.model.Sender
-import fr.vsct.tock.bot.connector.messenger.model.send.MessageRequest
 import fr.vsct.tock.bot.connector.messenger.model.webhook.Message
 import fr.vsct.tock.bot.connector.messenger.model.webhook.MessageEcho
 import fr.vsct.tock.bot.connector.messenger.model.webhook.MessageEchoWebhook
 import fr.vsct.tock.bot.connector.messenger.model.webhook.MessageWebhook
 import fr.vsct.tock.bot.connector.messenger.model.webhook.Optin
 import fr.vsct.tock.bot.connector.messenger.model.webhook.OptinWebhook
-import fr.vsct.tock.bot.connector.messenger.model.webhook.UserActionPayload
 import fr.vsct.tock.bot.connector.messenger.model.webhook.PostbackWebhook
+import fr.vsct.tock.bot.connector.messenger.model.webhook.UserActionPayload
 import fr.vsct.tock.bot.connector.messenger.model.webhook.Webhook
 import fr.vsct.tock.shared.jackson.mapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 class WebhookDeserializationTest {
@@ -45,7 +44,8 @@ class WebhookDeserializationTest {
     @Test
     fun testMessageWebhookWithEmptyAttachmentDeserialization() {
         val m = MessageWebhook(Sender("1"), Recipient("2"), 1L, Message("aa", 2, "text"))
-        val s = """{"sender":{"id":"1"},"recipient":{"id":"2"},"timestamp":1,"message":{"mid":"aa","seq":2,"text":"text","attachments":[{}]}}"""
+        val s =
+            """{"sender":{"id":"1"},"recipient":{"id":"2"},"timestamp":1,"message":{"mid":"aa","seq":2,"text":"text","attachments":[{}]}}"""
         assertEquals(m, mapper.readValue<Webhook>(s))
     }
 
@@ -90,17 +90,19 @@ class WebhookDeserializationTest {
                 "  }\n" +
                 "} "
         val output = mapper.readValue<MessageWebhook>(input)
-        assertEquals(MessageWebhook(
+        assertEquals(
+            MessageWebhook(
                 Sender("USER_ID"),
                 Recipient("PAGE_ID"),
                 1464990849275,
                 Message(
                     "mid.1464990849238:b9a22a2bcb1de31773",
-                        69,
-                        "Red",
-                        emptyList(),
-                        UserActionPayload("DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED")
+                    69,
+                    "Red",
+                    emptyList(),
+                    UserActionPayload("DEVELOPER_DEFINED_PAYLOAD_FOR_PICKING_RED")
                 )
-        ), output)
+            ), output
+        )
     }
 }

--- a/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/model/send/CustomEventRequestTest.kt
+++ b/bot/connector-messenger/src/test/kotlin/fr/vsct/tock/bot/connector/messenger/model/send/CustomEventRequestTest.kt
@@ -1,7 +1,7 @@
 package fr.vsct.tock.bot.connector.messenger.model.send
 
 import fr.vsct.tock.shared.jackson.mapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 

--- a/bot/connector-rest-client/pom.xml
+++ b/bot/connector-rest-client/pom.xml
@@ -55,13 +55,18 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bot/connector-rest/pom.xml
+++ b/bot/connector-rest/pom.xml
@@ -45,12 +45,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bot/connector-slack/pom.xml
+++ b/bot/connector-slack/pom.xml
@@ -36,12 +36,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/connector-slack/src/test/kotlin/fr/vsct/tock/bot/connector/slack/SlackBuildersTest.kt
+++ b/bot/connector-slack/src/test/kotlin/fr/vsct/tock/bot/connector/slack/SlackBuildersTest.kt
@@ -20,8 +20,8 @@ import fr.vsct.tock.bot.connector.slack.model.AttachmentField
 import fr.vsct.tock.bot.engine.BotBus
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 
@@ -29,7 +29,7 @@ class SlackBuildersTest {
 
     val bus: BotBus = mockk<BotBus>(relaxed = true)
 
-    @Before
+    @BeforeEach
     fun init() {
         every { bus.translate(any<CharSequence>()) } answers { firstArg() }
         every { bus.translateAndReturnBlankAsNull(any()) } answers { firstArg() }

--- a/bot/connector-slack/src/test/kotlin/fr/vsct/tock/bot/connector/slack/SlackEncoderTest.kt
+++ b/bot/connector-slack/src/test/kotlin/fr/vsct/tock/bot/connector/slack/SlackEncoderTest.kt
@@ -21,9 +21,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.web.RoutingContext
-import org.junit.Before
-import org.junit.Test
-
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 

--- a/bot/connector-slack/src/test/kotlin/fr/vsct/tock/bot/connector/slack/model/SlackMessageInTest.kt
+++ b/bot/connector-slack/src/test/kotlin/fr/vsct/tock/bot/connector/slack/model/SlackMessageInTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.bot.connector.slack.model
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/bot/engine-jackson/pom.xml
+++ b/bot/engine-jackson/pom.xml
@@ -37,12 +37,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bot/engine-jackson/src/test/kotlin/fr/vsct/tock/bot/jackson/MessageSerializationTest.kt
+++ b/bot/engine-jackson/src/test/kotlin/fr/vsct/tock/bot/jackson/MessageSerializationTest.kt
@@ -25,7 +25,7 @@ import fr.vsct.tock.bot.engine.message.Message
 import fr.vsct.tock.bot.engine.message.Sentence
 import fr.vsct.tock.bot.engine.user.UserLocation
 import fr.vsct.tock.shared.jackson.mapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -33,9 +33,10 @@ import kotlin.test.assertEquals
  */
 class MessageSerializationTest {
     data class MessageRequest(
-            val userId: String,
-            val recipientId: String,
-            val message: Message)
+        val userId: String,
+        val recipientId: String,
+        val message: Message
+    )
 
     init {
         BotEngineJacksonConfiguration.init()

--- a/bot/engine/pom.xml
+++ b/bot/engine/pom.xml
@@ -49,12 +49,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/definition/BotDefinitionTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/definition/BotDefinitionTest.kt
@@ -19,7 +19,7 @@ package fr.vsct.tock.bot.definition
 import fr.vsct.tock.bot.connector.ConnectorType
 import fr.vsct.tock.bot.engine.BotDefinitionTest
 import fr.vsct.tock.translator.I18nLabelKey
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.Locale
 import kotlin.test.assertEquals
 
@@ -34,12 +34,13 @@ class BotDefinitionTest {
     fun `i18nTranslator() returns an I18nTranslator that use BotDefinition#i18nKeyFromLabel`() {
         val result = botDef.i18nTranslator(Locale.ENGLISH, ConnectorType.none).i18nKeyFromLabel("test")
         assertEquals(
-                I18nLabelKey(
-                        "bottest_test",
-                        "namespace",
-                        "bottest",
-                        "test"
-                )
-                , result)
+            I18nLabelKey(
+                "bottest_test",
+                "namespace",
+                "bottest",
+                "test"
+            )
+            , result
+        )
     }
 }

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/definition/DefinitionBuildersTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/definition/DefinitionBuildersTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.bot.definition
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/definition/StoryHandlerBaseTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/definition/StoryHandlerBaseTest.kt
@@ -27,7 +27,7 @@ import fr.vsct.tock.bot.engine.TestStoryDefinition.test
 import fr.vsct.tock.bot.engine.TestStoryDefinition.test2
 import fr.vsct.tock.bot.engine.TockBotBus
 import fr.vsct.tock.translator.UserInterfaceType
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotBusTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotBusTest.kt
@@ -25,7 +25,7 @@ import fr.vsct.tock.bot.engine.message.Choice
 import fr.vsct.tock.bot.engine.user.UserPreferences
 import io.mockk.every
 import io.mockk.verify
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotEngineTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotEngineTest.kt
@@ -49,8 +49,8 @@ import fr.vsct.tock.shared.tockInternalInjector
 import fr.vsct.tock.translator.I18nDAO
 import fr.vsct.tock.translator.TranslatorEngine
 import io.mockk.mockk
-import org.junit.After
-import org.junit.Before
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 
 /**
  *
@@ -112,7 +112,7 @@ abstract class BotEngineTest {
         }
     }
 
-    @Before
+    @BeforeEach
     fun before() {
         tockInternalInjector = KodeinInjector()
         injector.inject(Kodein {
@@ -120,7 +120,7 @@ abstract class BotEngineTest {
         })
     }
 
-    @After
+    @AfterEach
     fun after() {
         tockInternalInjector = KodeinInjector()
     }

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotRepositoryTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotRepositoryTest.kt
@@ -24,39 +24,42 @@ import fr.vsct.tock.bot.engine.BotRepository.botProviders
 import fr.vsct.tock.bot.engine.ConnectorConfigurationRepository.addConfiguration
 import fr.vsct.tock.shared.defaultLocale
 import io.mockk.verify
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  *
  */
 class BotRepositoryTest : BotEngineTest() {
 
-    @Before
+    @BeforeEach
     fun beforeTest() {
         ConnectorConfigurationRepository.cleanup()
         botProviders.clear()
     }
 
-    @Test(expected = IllegalStateException::class)
+    @Test
     fun `installBots with two configurations of the same id throws error`() {
-        addConfiguration(
-            ConnectorConfiguration(
-                "id",
-                "",
-                ConnectorType.none,
-                ConnectorType.none
+        assertThrows<IllegalStateException> {
+            addConfiguration(
+                ConnectorConfiguration(
+                    "id",
+                    "",
+                    ConnectorType.none,
+                    ConnectorType.none
+                )
             )
-        )
-        addConfiguration(
-            ConnectorConfiguration(
-                "id",
-                "",
-                ConnectorType.none,
-                ConnectorType.none
+            addConfiguration(
+                ConnectorConfiguration(
+                    "id",
+                    "",
+                    ConnectorType.none,
+                    ConnectorType.none
+                )
             )
-        )
-        BotRepository.installBots(emptyList())
+            BotRepository.installBots(emptyList())
+        }
     }
 
     @Test

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/BotTest.kt
@@ -20,7 +20,7 @@ import fr.vsct.tock.bot.engine.TestStoryDefinition.test
 import fr.vsct.tock.bot.engine.action.SendChoice
 import fr.vsct.tock.bot.engine.message.Choice
 import io.mockk.verify
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -38,15 +38,15 @@ class BotTest : BotEngineTest() {
     @Test
     fun handleSendChoice_shouldNotReturnUnknownStory_whenIntentIsSecondaryIntentAndNoStoryExists() {
         val choice = action(
-                Choice(
-                        secondaryIntent.name,
-                        mapOf(
-                                SendChoice.PREVIOUS_INTENT_PARAMETER to test.name
-                        )
+            Choice(
+                secondaryIntent.name,
+                mapOf(
+                    SendChoice.PREVIOUS_INTENT_PARAMETER to test.name
                 )
+            )
         )
         dialog.stories.clear()
-        bot.handle(choice, userTimeline, connectorController,connectorData)
+        bot.handle(choice, userTimeline, connectorController, connectorData)
 
         assertEquals(story.definition.id, dialog.currentStory()!!.definition.id)
         assertEquals(test.mainIntent(), dialog.currentStory()!!.starterIntent)

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/action/SendChoiceTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/action/SendChoiceTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.bot.engine.action
 
 import fr.vsct.tock.bot.definition.Intent
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/dialog/EntityStateValueTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/dialog/EntityStateValueTest.kt
@@ -18,7 +18,7 @@ package fr.vsct.tock.bot.engine.dialog
 import fr.vsct.tock.nlp.api.client.model.Entity
 import fr.vsct.tock.nlp.api.client.model.EntityType
 import fr.vsct.tock.nlp.entity.NumberValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/message/parser/MessageParserTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/message/parser/MessageParserTest.kt
@@ -25,7 +25,7 @@ import fr.vsct.tock.bot.engine.message.Sentence
 import fr.vsct.tock.bot.engine.message.SentenceElement
 import fr.vsct.tock.bot.engine.message.SentenceSubElement
 import fr.vsct.tock.bot.engine.user.UserLocation
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -72,50 +72,62 @@ class MessageParserTest {
     @Test
     fun parse_shouldWork_forSentenceWithChoicesAndTextsAndMetaData() {
         val s = Sentence(
-                null,
-                mutableListOf(
-                        SentenceElement(
-                                texts = mapOf("1" to "2", "3" to "4"),
-                                metadata = mapOf("a" to "b", "c" to "d"),
-                                choices = listOf(
-                                        Choice("intent1"),
-                                        Choice("intent2", mapOf("1" to "2", "3" to "4")
-                                        ))
-                        )))
+            null,
+            mutableListOf(
+                SentenceElement(
+                    texts = mapOf("1" to "2", "3" to "4"),
+                    metadata = mapOf("a" to "b", "c" to "d"),
+                    choices = listOf(
+                        Choice("intent1"),
+                        Choice(
+                            "intent2", mapOf("1" to "2", "3" to "4")
+                        )
+                    )
+                )
+            )
+        )
         assertEquals(s, MessageParser.parse(s.toPrettyString()).first())
     }
 
     @Test
     fun parse_shouldWork_forSentenceWithChoicesAndTextsAndMetaDataAndSubElements() {
         val s = Sentence(
-                null,
-                mutableListOf(
-                        SentenceElement(
-                                texts = mapOf("1" to "2", "3" to "4"),
-                                metadata = mapOf("a" to "b", "c" to "d"),
-                                choices = listOf(
-                                        Choice("intent1"),
-                                        Choice("intent2", mapOf("1" to "2", "3" to "4")
-                                        )),
-                                subElements = listOf(
-                                        SentenceSubElement(
-                                                texts = mapOf("1" to "2", "3" to "4"),
-                                                metadata = mapOf("a" to "b", "c" to "d"),
-                                                choices = listOf(
-                                                        Choice("intent1"),
-                                                        Choice("intent2", mapOf("1" to "2", "3" to "4")
-                                                        ))
-                                        ),
-                                        SentenceSubElement(
-                                                texts = mapOf("1" to "2", "3" to "4"),
-                                                metadata = mapOf("a" to "b", "c" to "d"),
-                                                choices = listOf(
-                                                        Choice("intent1"),
-                                                        Choice("intent2", mapOf("1" to "2", "3" to "4")
-                                                        ))
-                                        )
+            null,
+            mutableListOf(
+                SentenceElement(
+                    texts = mapOf("1" to "2", "3" to "4"),
+                    metadata = mapOf("a" to "b", "c" to "d"),
+                    choices = listOf(
+                        Choice("intent1"),
+                        Choice(
+                            "intent2", mapOf("1" to "2", "3" to "4")
+                        )
+                    ),
+                    subElements = listOf(
+                        SentenceSubElement(
+                            texts = mapOf("1" to "2", "3" to "4"),
+                            metadata = mapOf("a" to "b", "c" to "d"),
+                            choices = listOf(
+                                Choice("intent1"),
+                                Choice(
+                                    "intent2", mapOf("1" to "2", "3" to "4")
                                 )
-                        )))
+                            )
+                        ),
+                        SentenceSubElement(
+                            texts = mapOf("1" to "2", "3" to "4"),
+                            metadata = mapOf("a" to "b", "c" to "d"),
+                            choices = listOf(
+                                Choice("intent1"),
+                                Choice(
+                                    "intent2", mapOf("1" to "2", "3" to "4")
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
         assertEquals(s, MessageParser.parse(s.toPrettyString()).first())
     }
 

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/nlp/NlpTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/nlp/NlpTest.kt
@@ -30,7 +30,7 @@ import fr.vsct.tock.nlp.entity.Value
 import io.mockk.every
 import io.mockk.slot
 import io.mockk.verify
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue

--- a/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/user/TimeBoxedFlagTest.kt
+++ b/bot/engine/src/test/kotlin/fr/vsct/tock/bot/engine/user/TimeBoxedFlagTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.bot.engine.user
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.Instant
 import kotlin.test.assertTrue
 

--- a/bot/storage-mongo/pom.xml
+++ b/bot/storage-mongo/pom.xml
@@ -44,12 +44,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/AbstractTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/AbstractTest.kt
@@ -27,7 +27,7 @@ import fr.vsct.tock.bot.mongo.MONGO_DATABASE
 import fr.vsct.tock.bot.mongo.UserTimelineCol
 import fr.vsct.tock.shared.sharedTestModule
 import fr.vsct.tock.shared.tockInternalInjector
-import org.junit.Before
+import org.junit.jupiter.api.BeforeEach
 import org.litote.kmongo.KFongoRule.Companion.rule
 
 /**
@@ -43,7 +43,7 @@ abstract class AbstractTest {
         }
     }
 
-    @Before
+    @BeforeEach
     fun before() {
         tockInternalInjector = KodeinInjector()
         tockInternalInjector.inject(Kodein {

--- a/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/DialogColDeserializationTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/DialogColDeserializationTest.kt
@@ -31,7 +31,7 @@ import fr.vsct.tock.nlp.api.client.model.NlpIntentQualifier
 import fr.vsct.tock.shared.jackson.AnyValueWrapper
 import fr.vsct.tock.shared.jackson.mapper
 import io.mockk.mockk
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
@@ -45,8 +45,9 @@ class DialogColDeserializationTest : AbstractTest() {
     @Test
     fun serializeAndDeserializeAnyValueWrapper_shouldLeftDataInchanged() {
         val value = AnyValueWrapper(
-                UserLocation::class,
-                UserLocation(1.0, 2.0))
+            UserLocation::class,
+            UserLocation(1.0, 2.0)
+        )
         val s = mapper.writeValueAsString(value)
         val newValue = mapper.readValue<AnyValueWrapper>(s)
         assertEquals(value, newValue)
@@ -55,23 +56,25 @@ class DialogColDeserializationTest : AbstractTest() {
     @Test
     fun serializeAndDeserializeStateMongoWrapper_shouldLeftDataInchanged() {
         val state = DialogStateMongoWrapper(
-                Intent("test"),
-                mapOf("role" to EntityStateValueWrapper(
-                        ContextValue(
-                                0,
-                                1,
-                                Entity(EntityType("type"), "role"),
-                                "content"
-                        ),
-                        emptyList()
-                )),
-                emptyMap(),
-                UserLocation(1.0, 2.0),
-                NextUserActionState(
-                        listOf(NlpIntentQualifier("test")),
-                        ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC")),
-                        ZoneId.systemDefault()
+            Intent("test"),
+            mapOf(
+                "role" to EntityStateValueWrapper(
+                    ContextValue(
+                        0,
+                        1,
+                        Entity(EntityType("type"), "role"),
+                        "content"
+                    ),
+                    emptyList()
                 )
+            ),
+            emptyMap(),
+            UserLocation(1.0, 2.0),
+            NextUserActionState(
+                listOf(NlpIntentQualifier("test")),
+                ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC")),
+                ZoneId.systemDefault()
+            )
         )
         val s = mapper.writeValueAsString(state)
         val newValue = mapper.readValue<DialogStateMongoWrapper>(s)
@@ -82,8 +85,9 @@ class DialogColDeserializationTest : AbstractTest() {
     @Test
     fun serializeAndDeserializeDialog_shouldLeftDataInchanged() {
         val dialog = Dialog(
-                emptySet(),
-                state = fr.vsct.tock.bot.engine.dialog.DialogState(context = mutableMapOf("a" to LocalDateTime.now())))
+            emptySet(),
+            state = fr.vsct.tock.bot.engine.dialog.DialogState(context = mutableMapOf("a" to LocalDateTime.now()))
+        )
         val playerId = PlayerId("a", PlayerType.user)
         val s = mapper.writeValueAsString(DialogCol(dialog, UserTimelineCol(UserTimeline(playerId), null)))
         val newValue = mapper.readValue<DialogCol>(s)

--- a/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserPreferencesWrapperTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserPreferencesWrapperTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.bot.engine.user
 
 import fr.vsct.tock.bot.mongo.UserTimelineCol.UserPreferencesWrapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue

--- a/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserStateWrapperTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserStateWrapperTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.bot.engine.user
 
 import fr.vsct.tock.bot.mongo.UserTimelineCol.UserStateWrapper
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals

--- a/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserTimelineMongoDAOIntegrationTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserTimelineMongoDAOIntegrationTest.kt
@@ -24,7 +24,7 @@ import fr.vsct.tock.bot.mongo.botMongoModule
 import fr.vsct.tock.shared.defaultNamespace
 import fr.vsct.tock.shared.injector
 import fr.vsct.tock.shared.sharedModule
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.Locale
 
 /**
@@ -40,13 +40,15 @@ class UserTimelineMongoDAOIntegrationTest {
 
     @Test
     fun testSearch() {
-        println(UserTimelineMongoDAO.search(
+        println(
+            UserTimelineMongoDAO.search(
                 UserReportQuery(
-                        defaultNamespace,
-                        "bot_open_data",
-                        Locale.FRENCH,
-                        flags = mapOf("tock_profile_loaded" to "true")
+                    defaultNamespace,
+                    "bot_open_data",
+                    Locale.FRENCH,
+                    flags = mapOf("tock_profile_loaded" to "true")
                 )
-        ))
+            )
+        )
     }
 }

--- a/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserTimelineMongoDAOTest.kt
+++ b/bot/storage-mongo/src/test/kotlin/fr/vsct/tock/bot/engine/user/UserTimelineMongoDAOTest.kt
@@ -18,7 +18,7 @@ package fr.vsct.tock.bot.engine.user
 
 import fr.vsct.tock.bot.engine.dialog.Dialog
 import fr.vsct.tock.bot.mongo.UserTimelineMongoDAO
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/bot/test/pom.xml
+++ b/bot/test/pom.xml
@@ -28,6 +28,10 @@
     <name>Tock Bot Test Toolkit</name>
     <description>Bot Test helpers and mocks</description>
 
+    <properties>
+        <junit4>4.12</junit4>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>fr.vsct.tock</groupId>
@@ -35,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -48,6 +52,17 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>provided</scope>
+            <version>${junit4}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bot/test/src/main/kotlin/fr/vsct/tock/bot/test/junit/TockJUnit5Extension.kt
+++ b/bot/test/src/main/kotlin/fr/vsct/tock/bot/test/junit/TockJUnit5Extension.kt
@@ -1,0 +1,82 @@
+package fr.vsct.tock.bot.test.junit
+
+import fr.vsct.tock.bot.connector.ConnectorType
+import fr.vsct.tock.bot.definition.BotDefinition
+import fr.vsct.tock.bot.definition.StoryDefinition
+import fr.vsct.tock.bot.engine.user.PlayerId
+import fr.vsct.tock.bot.test.BotBusMock
+import fr.vsct.tock.bot.test.BotBusMockContext
+import fr.vsct.tock.bot.test.TestContext
+import fr.vsct.tock.bot.test.TestLifecycle
+import fr.vsct.tock.bot.test.newBusMockContext
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.util.Locale
+
+open class TockJUnit5Extension<out T : TestContext>(
+    val botDefinition: BotDefinition,
+    @Suppress("UNCHECKED_CAST") val lifecycle: TestLifecycle<T> = TestLifecycle(TestContext() as T)
+) : BeforeEachCallback, AfterEachCallback {
+
+    /**
+     * The [TestContext].
+     */
+    val testContext: T get() = lifecycle.testContext
+
+    /**
+     * Provides a mock initialized with the specified [StoryDefinition] and starts the story.
+     */
+    fun startNewBusMock(
+        story: StoryDefinition = testContext.defaultStoryDefinition(botDefinition),
+        connectorType: ConnectorType = testContext.defaultConnectorType(),
+        locale: Locale = testContext.defaultLocale(),
+        userId: PlayerId = testContext.defaultPlayerId()
+    )
+            : BotBusMock = newBusMock(story, connectorType, locale, userId).run()
+
+    /**
+     * Provides a mock initialized with the specified [StoryDefinition].
+     */
+    fun newBusMock(
+        story: StoryDefinition = testContext.defaultStoryDefinition(botDefinition),
+        connectorType: ConnectorType = testContext.defaultConnectorType(),
+        locale: Locale = testContext.defaultLocale(),
+        userId: PlayerId = testContext.defaultPlayerId()
+    )
+            : BotBusMock = BotBusMock(newBusMockContext(story, connectorType, locale, userId))
+
+    /**
+     * Provides a mock context initialized with the specified [StoryDefinition].
+     */
+    fun newBusMockContext(
+        story: StoryDefinition = testContext.defaultStoryDefinition(botDefinition),
+        connectorType: ConnectorType = testContext.defaultConnectorType(),
+        locale: Locale = testContext.defaultLocale(),
+        userId: PlayerId = testContext.defaultPlayerId()
+    ): BotBusMockContext = botDefinition.newBusMockContext(testContext, story, connectorType, locale, userId)
+        .apply {
+            testContext.botBusMockContext = this
+            lifecycle.configureTestIoc()
+        }
+
+    /**
+     * Provides a mock context initialized with the current [testContext] and runs the bus.
+     */
+    fun startBusMock(): BotBusMock = busMock().run()
+
+    /**
+     * Provides a mock context initialized with the current [testContext].
+     */
+    fun busMock(): BotBusMock = BotBusMock(testContext.botBusMockContext)
+
+
+    override fun beforeEach(p0: ExtensionContext) {
+        lifecycle.start()
+    }
+
+    override fun afterEach(p0: ExtensionContext) {
+        lifecycle.end()
+    }
+
+}

--- a/nlp/api/client/pom.xml
+++ b/nlp/api/client/pom.xml
@@ -63,13 +63,18 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nlp/api/client/src/test/kotlin/fr/vsct/tock/nlp/api/client/NlpClientIntegrationTest.kt
+++ b/nlp/api/client/src/test/kotlin/fr/vsct/tock/nlp/api/client/NlpClientIntegrationTest.kt
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import fr.vsct.tock.nlp.api.client.model.dump.ApplicationDump
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/nlp/api/service/pom.xml
+++ b/nlp/api/service/pom.xml
@@ -48,12 +48,16 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
         </dependency>
     </dependencies>
 

--- a/nlp/api/service/src/test/kotlin/fr/vsct/tock/nlp/api/ParseResultSerializationTest.kt
+++ b/nlp/api/service/src/test/kotlin/fr/vsct/tock/nlp/api/ParseResultSerializationTest.kt
@@ -26,9 +26,9 @@ import fr.vsct.tock.nlp.front.shared.parser.ParseResult
 import fr.vsct.tock.nlp.front.shared.parser.ParsedEntityValue
 import fr.vsct.tock.shared.defaultLocale
 import fr.vsct.tock.shared.jackson.mapper
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals
@@ -39,12 +39,12 @@ import kotlin.test.assertEquals
  */
 class ParseResultSerializationTest {
 
-    @Before()
+    @BeforeEach
     fun before() {
         mapper.enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID)
     }
 
-    @After
+    @AfterEach
     fun after() {
         mapper.disable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID)
     }
@@ -52,23 +52,27 @@ class ParseResultSerializationTest {
     @Test
     fun testEntityValueDeserializationAndSerialization() {
         val parseResult = ParseResult(
-                "test",
-                "namespace",
-                defaultLocale,
-                listOf(ParsedEntityValue(
-                        0,
-                        1,
-                        Entity(EntityType("type"), "role"),
-                        DateEntityValue(ZonedDateTime.of(2017, 4, 1, 0, 0, 0, 0, ZoneId.of("UTC")), DateEntityGrain.day)
-                )),
-                1.0,
-                1.0,
-                "sentence",
-                mapOf("test2" to 2.0))
+            "test",
+            "namespace",
+            defaultLocale,
+            listOf(
+                ParsedEntityValue(
+                    0,
+                    1,
+                    Entity(EntityType("type"), "role"),
+                    DateEntityValue(ZonedDateTime.of(2017, 4, 1, 0, 0, 0, 0, ZoneId.of("UTC")), DateEntityGrain.day)
+                )
+            ),
+            1.0,
+            1.0,
+            "sentence",
+            mapOf("test2" to 2.0)
+        )
         val s = mapper.writeValueAsString(parseResult)
         assertEquals(
-                """{"intent":"test","intentNamespace":"namespace","language":"$defaultLocale","entities":[{"start":0,"end":1,"entity":{"entityType":{"name":"type","subEntities":[]},"role":"role"},"value":{"@type":"dateEntity","date":"2017-04-01T00:00:00Z[UTC]","grain":"day"},"evaluated":false,"subEntities":[],"probability":1.0,"mergeSupport":false}],"intentProbability":1.0,"entitiesProbability":1.0,"retainedQuery":"sentence","otherIntentsProbabilities":{"test2":2.0}}""",
-                s)
+            """{"intent":"test","intentNamespace":"namespace","language":"$defaultLocale","entities":[{"start":0,"end":1,"entity":{"entityType":{"name":"type","subEntities":[]},"role":"role"},"value":{"@type":"dateEntity","date":"2017-04-01T00:00:00Z[UTC]","grain":"day"},"evaluated":false,"subEntities":[],"probability":1.0,"mergeSupport":false}],"intentProbability":1.0,"entitiesProbability":1.0,"retainedQuery":"sentence","otherIntentsProbabilities":{"test2":2.0}}""",
+            s
+        )
 
         assertEquals(parseResult, mapper.readValue(s))
     }

--- a/nlp/build-model-worker/pom.xml
+++ b/nlp/build-model-worker/pom.xml
@@ -48,12 +48,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nlp/core/service/pom.xml
+++ b/nlp/core/service/pom.xml
@@ -40,12 +40,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nlp/core/service/src/test/kotlin/fr/vsct/tock/nlp/core/service/entity/EntityMergeServiceTest.kt
+++ b/nlp/core/service/src/test/kotlin/fr/vsct/tock/nlp/core/service/entity/EntityMergeServiceTest.kt
@@ -23,7 +23,7 @@ import fr.vsct.tock.nlp.core.EntityRecognition
 import fr.vsct.tock.nlp.core.EntityType
 import fr.vsct.tock.nlp.core.EntityValue
 import fr.vsct.tock.nlp.core.Intent
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.Locale
 import kotlin.test.assertEquals
 
@@ -32,10 +32,9 @@ import kotlin.test.assertEquals
  */
 class EntityMergeServiceTest {
 
-    private val callContext
-            = CallContext(
-            Application("test", emptyList(), emptySet()),
-            Locale.US
+    private val callContext = CallContext(
+        Application("test", emptyList(), emptySet()),
+        Locale.US
     )
 
     @Test
@@ -45,22 +44,30 @@ class EntityMergeServiceTest {
         val tomorrow = EntityRecognition(EntityValue(0, "Tomorrow".length, dateEntity), 0.98)
         val tomorrowMorning = EntityTypeRecognition(EntityTypeValue(0, "Tomorrow morning".length, entityType), 0.8)
         val result = EntityMergeService.mergeEntityTypes(
-                callContext,
-                "Tomorrow morning",
-                Intent("test", listOf(dateEntity)),
-                listOf(tomorrow),
-                listOf(tomorrowMorning))
+            callContext,
+            "Tomorrow morning",
+            Intent("test", listOf(dateEntity)),
+            listOf(tomorrow),
+            listOf(tomorrowMorning)
+        )
 
-        assertEquals(listOf(
+        assertEquals(
+            listOf(
                 EntityRecognition(
-                        value = EntityValue(
-                                start = 0,
-                                end = 16,
-                                entity = Entity(
-                                        entityType = EntityType(
-                                                name = "test"), role = "test")),
-                        probability = 0.8)),
-                result)
+                    value = EntityValue(
+                        start = 0,
+                        end = 16,
+                        entity = Entity(
+                            entityType = EntityType(
+                                name = "test"
+                            ), role = "test"
+                        )
+                    ),
+                    probability = 0.8
+                )
+            ),
+            result
+        )
     }
 
     @Test
@@ -73,22 +80,30 @@ class EntityMergeServiceTest {
         val tomorrowMorning = EntityTypeRecognition(EntityTypeValue(0, "sun tomorrow".length, dateEntityType), 0.8)
 
         val result = EntityMergeService.mergeEntityTypes(
-                callContext,
-                "sun tomorrow",
-                Intent("test", listOf(entity, dateEntity)),
-                listOf(tomorrow),
-                listOf(tomorrowMorning))
+            callContext,
+            "sun tomorrow",
+            Intent("test", listOf(entity, dateEntity)),
+            listOf(tomorrow),
+            listOf(tomorrowMorning)
+        )
 
-        assertEquals(listOf(
+        assertEquals(
+            listOf(
                 EntityRecognition(
-                        value = EntityValue(
-                                start = 0,
-                                end = 12,
-                                entity = Entity(
-                                        entityType = EntityType(
-                                                name = "date"), role = "dateRole")),
-                        probability = 0.8)),
-                result)
+                    value = EntityValue(
+                        start = 0,
+                        end = 12,
+                        entity = Entity(
+                            entityType = EntityType(
+                                name = "date"
+                            ), role = "dateRole"
+                        )
+                    ),
+                    probability = 0.8
+                )
+            ),
+            result
+        )
     }
 
     @Test
@@ -98,24 +113,35 @@ class EntityMergeServiceTest {
         val dateEntityType = EntityType("date")
         val dateEntity = Entity(dateEntityType, "dateRole")
         val tomorrow = EntityRecognition(EntityValue(0, "the sun".length, entity), 0.98)
-        val tomorrowMorning = EntityTypeRecognition(EntityTypeValue("the ".length, "the ".length + "sun tomorrow".length, dateEntityType), 0.8)
+        val tomorrowMorning = EntityTypeRecognition(
+            EntityTypeValue("the ".length, "the ".length + "sun tomorrow".length, dateEntityType),
+            0.8
+        )
 
         val result = EntityMergeService.mergeEntityTypes(
-                callContext,
-                "the sun tomorrow",
-                Intent("test", listOf(entity, dateEntity)),
-                listOf(tomorrow),
-                listOf(tomorrowMorning))
+            callContext,
+            "the sun tomorrow",
+            Intent("test", listOf(entity, dateEntity)),
+            listOf(tomorrow),
+            listOf(tomorrowMorning)
+        )
 
-        assertEquals(listOf(
+        assertEquals(
+            listOf(
                 EntityRecognition(
-                        value = EntityValue(
-                                start = 0,
-                                end = 7,
-                                entity = Entity(
-                                        entityType = EntityType(
-                                                name = "test"), role = "role")),
-                        probability = 0.98)),
-                result)
+                    value = EntityValue(
+                        start = 0,
+                        end = 7,
+                        entity = Entity(
+                            entityType = EntityType(
+                                name = "test"
+                            ), role = "role"
+                        )
+                    ),
+                    probability = 0.98
+                )
+            ),
+            result
+        )
     }
 }

--- a/nlp/entity-evaluator/duckling/client/src/test/kotlin/fr/vsct/tock/duckling/client/DatesMergeTest.kt
+++ b/nlp/entity-evaluator/duckling/client/src/test/kotlin/fr/vsct/tock/duckling/client/DatesMergeTest.kt
@@ -30,7 +30,7 @@ import fr.vsct.tock.nlp.model.EntityCallContextForEntity
 import fr.vsct.tock.shared.injector
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.util.Locale
@@ -45,80 +45,94 @@ internal class DatesMergeTest {
         val referenceTime: ZonedDateTime = ZonedDateTime.now()
 
         val context = EntityCallContextForEntity(
-                EntityType("duckling:datetime"),
-                Locale.FRENCH,
-                NlpEngineType.opennlp,
-                referenceTime)
+            EntityType("duckling:datetime"),
+            Locale.FRENCH,
+            NlpEngineType.opennlp,
+            referenceTime
+        )
 
         val tomorrow = ValueDescriptor(
-                DateEntityValue(
-                        referenceTime.plusDays(1),
-                        DateEntityGrain.day
-                ),
-                "demain",
-                false,
-                12)
+            DateEntityValue(
+                referenceTime.plusDays(1),
+                DateEntityGrain.day
+            ),
+            "demain",
+            false,
+            12
+        )
 
         val twoDaysAfter = ValueDescriptor(
-                DateEntityValue(
-                        referenceTime.plusDays(2),
-                        DateEntityGrain.day
-                ),
-                "2 jours Après",
-                false,
-                12,
-                0.8)
+            DateEntityValue(
+                referenceTime.plusDays(2),
+                DateEntityGrain.day
+            ),
+            "2 jours Après",
+            false,
+            12,
+            0.8
+        )
 
         val evening = ValueDescriptor(
-                DateIntervalEntityValue(
-                        DateEntityValue(referenceTime.withHour(18), DateEntityGrain.hour),
-                        DateEntityValue(referenceTime.withHour(23), DateEntityGrain.hour)
-                ),
-                "en soirée",
-                false,
-                2)
+            DateIntervalEntityValue(
+                DateEntityValue(referenceTime.withHour(18), DateEntityGrain.hour),
+                DateEntityValue(referenceTime.withHour(23), DateEntityGrain.hour)
+            ),
+            "en soirée",
+            false,
+            2
+        )
 
         val tomorrowInTheEvening = DateIntervalEntityValue(
-                DateEntityValue(referenceTime.plusDays(1).withHour(18), DateEntityGrain.hour),
-                DateEntityValue(referenceTime.plusDays(1).withHour(23), DateEntityGrain.hour)
+            DateEntityValue(referenceTime.plusDays(1).withHour(18), DateEntityGrain.hour),
+            DateEntityValue(referenceTime.plusDays(1).withHour(23), DateEntityGrain.hour)
         )
 
         val tomorrowAt8 = ValueDescriptor(
-                DateEntityValue(
-                        referenceTime.plusDays(1).withHour(20),
-                        DateEntityGrain.hour
-                ),
-                "demain à 20h",
-                false,
-                2)
+            DateEntityValue(
+                referenceTime.plusDays(1).withHour(20),
+                DateEntityGrain.hour
+            ),
+            "demain à 20h",
+            false,
+            2
+        )
 
         val inThreeDays =
-                DateEntityValue(
-                        referenceTime.plusDays(3),
-                        DateEntityGrain.day
-                )
+            DateEntityValue(
+                referenceTime.plusDays(3),
+                DateEntityGrain.day
+            )
 
         val parser: Parser = mockk(relaxed = true)
 
         init {
 
-            every { parser.parse(
-                eq(Locale.FRENCH.language),
-                eq(timeDucklingDimension),
-                eq((tomorrow.value as DateEntityValue).date),
-                eq("2 jours Après")) } answers { listOf(ValueWithRange(0, 0, inThreeDays, timeDucklingDimension)) }
+            every {
+                parser.parse(
+                    eq(Locale.FRENCH.language),
+                    eq(timeDucklingDimension),
+                    eq((tomorrow.value as DateEntityValue).date),
+                    eq("2 jours Après")
+                )
+            } answers { listOf(ValueWithRange(0, 0, inThreeDays, timeDucklingDimension)) }
 
-            every { parser.parse(
-                eq(Locale.FRENCH.language),
-                eq(timeDucklingDimension),
-                eq(referenceTime),
-                eq("en soirée demain")) } answers { listOf(ValueWithRange(0, 0, tomorrowInTheEvening, timeDucklingDimension)) }
+            every {
+                parser.parse(
+                    eq(Locale.FRENCH.language),
+                    eq(timeDucklingDimension),
+                    eq(referenceTime),
+                    eq("en soirée demain")
+                )
+            } answers { listOf(ValueWithRange(0, 0, tomorrowInTheEvening, timeDucklingDimension)) }
 
-            every { parser.parse(
-                eq(Locale.FRENCH.language),
-                eq(timeDucklingDimension),
-                eq((tomorrow.value as DateEntityValue).date.truncatedTo(ChronoUnit.DAYS)),
-                eq("en soirée")) } answers { listOf(ValueWithRange(0, 0, tomorrowInTheEvening, timeDucklingDimension)) }
+            every {
+                parser.parse(
+                    eq(Locale.FRENCH.language),
+                    eq(timeDucklingDimension),
+                    eq((tomorrow.value as DateEntityValue).date.truncatedTo(ChronoUnit.DAYS)),
+                    eq("en soirée")
+                )
+            } answers { listOf(ValueWithRange(0, 0, tomorrowInTheEvening, timeDucklingDimension)) }
 
             injector.inject(Kodein {
                 bind<Parser>() with provider { parser }

--- a/nlp/entity-evaluator/duckling/client/src/test/kotlin/fr/vsct/tock/duckling/client/DucklingClientIntegrationTest.kt
+++ b/nlp/entity-evaluator/duckling/client/src/test/kotlin/fr/vsct/tock/duckling/client/DucklingClientIntegrationTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.duckling.client
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.time.Month
 import java.time.ZoneId
@@ -41,14 +41,20 @@ class DucklingClientIntegrationTest {
     fun testSimpleCall() {
         val result = DucklingClient.parse("fr", listOf("time"), now(), systemDefault(), "10 août 2055")
         println(result)
-        assertEquals(LocalDateTime.of(2055, Month.AUGUST, 10, 0, 0).atZone(systemDefault()).withFixedOffsetZone(), parse(result!![0][":value"][":values"][0][":value"].string(), formatter))
+        assertEquals(
+            LocalDateTime.of(2055, Month.AUGUST, 10, 0, 0).atZone(systemDefault()).withFixedOffsetZone(),
+            parse(result!![0][":value"][":values"][0][":value"].string(), formatter)
+        )
     }
 
     @Test
     fun testCallWithSpecialQuote() {
         val result = DucklingClient.parse("fr", listOf("time"), now(), systemDefault(), "Aujourd’hui")
         println(result)
-        assertEquals(LocalDateTime.now().atZone(systemDefault()).withFixedOffsetZone().truncatedTo(ChronoUnit.DAYS), parse(result!![0][":value"][":values"][0][":value"].string(), formatter))
+        assertEquals(
+            LocalDateTime.now().atZone(systemDefault()).withFixedOffsetZone().truncatedTo(ChronoUnit.DAYS),
+            parse(result!![0][":value"][":values"][0][":value"].string(), formatter)
+        )
     }
 
     @Test
@@ -56,12 +62,16 @@ class DucklingClientIntegrationTest {
         val referenceDate = now()
         val result = DucklingClient.parse("fr", listOf("time"), referenceDate, systemDefault(), "dans 1h")
         println(result)
-        assertEquals(referenceDate.plusHours(1).withSecond(0).withNano(0).withFixedOffsetZone(), parse(result!![0][":value"][":values"][0][":value"].string(), formatter))
+        assertEquals(
+            referenceDate.plusHours(1).withSecond(0).withNano(0).withFixedOffsetZone(),
+            parse(result!![0][":value"][":values"][0][":value"].string(), formatter)
+        )
     }
 
     @Test
     fun testIntervalDate() {
-        val result = DucklingClient.parse("fr", listOf("time"), now(), systemDefault(), "du samedi 3 au dimanche 4 septembre")
+        val result =
+            DucklingClient.parse("fr", listOf("time"), now(), systemDefault(), "du samedi 3 au dimanche 4 septembre")
         println(result)
         assertEquals(3, parse(result!![0][":value"][":from"][":value"].string(), formatter).dayOfMonth)
     }
@@ -73,19 +83,20 @@ class DucklingClientIntegrationTest {
         val result = DucklingClient.parse("fr", listOf("time"), now, zoneId, "dans 1h")
         println(result)
         assertEquals(
-                now.withZoneSameInstant(zoneId).plusHours(1).toLocalDateTime().truncatedTo(ChronoUnit.MINUTES),
-                parse(result!![0][":value"][":values"][0][":value"].string(), formatter).toLocalDateTime()
+            now.withZoneSameInstant(zoneId).plusHours(1).toLocalDateTime().truncatedTo(ChronoUnit.MINUTES),
+            parse(result!![0][":value"][":values"][0][":value"].string(), formatter).toLocalDateTime()
         )
     }
 
     @Test
     fun testCallWithTruncatedDay() {
         val now = now().plusDays(1)
-        val result = DucklingClient.parse("fr", listOf("time"), now.truncatedTo(ChronoUnit.DAYS), systemDefault(), "le soir")
+        val result =
+            DucklingClient.parse("fr", listOf("time"), now.truncatedTo(ChronoUnit.DAYS), systemDefault(), "le soir")
         println(result)
         assertEquals(
-                now.withHour(18).toLocalDateTime().truncatedTo(ChronoUnit.HOURS),
-                parse(result!![0][":value"][":from"][":value"].string(), formatter).toLocalDateTime()
+            now.withHour(18).toLocalDateTime().truncatedTo(ChronoUnit.HOURS),
+            parse(result!![0][":value"][":from"][":value"].string(), formatter).toLocalDateTime()
         )
     }
 

--- a/nlp/entity-evaluator/duckling/client/src/test/kotlin/fr/vsct/tock/duckling/client/DucklingParserIntegrationTest.kt
+++ b/nlp/entity-evaluator/duckling/client/src/test/kotlin/fr/vsct/tock/duckling/client/DucklingParserIntegrationTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.duckling.client
 
 import fr.vsct.tock.nlp.entity.NumberValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 

--- a/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateEntityGrainTest.kt
+++ b/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateEntityGrainTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.nlp.entity.date
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime

--- a/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateEntityValueDateSerializationTest.kt
+++ b/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateEntityValueDateSerializationTest.kt
@@ -17,10 +17,10 @@
 package fr.vsct.tock.nlp.entity.date
 
 import fr.vsct.tock.nlp.entity.Value
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import kotlin.test.assertEquals
 
 /**
  *

--- a/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateEntityValueTest.kt
+++ b/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateEntityValueTest.kt
@@ -18,7 +18,7 @@ package fr.vsct.tock.nlp.entity.date
 
 import fr.vsct.tock.nlp.entity.date.DateEntityGrain.day
 import fr.vsct.tock.nlp.entity.date.DateEntityGrain.hour
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals

--- a/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateIntervalEntityValueDateSerializationTest.kt
+++ b/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateIntervalEntityValueDateSerializationTest.kt
@@ -17,10 +17,10 @@
 package fr.vsct.tock.nlp.entity.date
 
 import fr.vsct.tock.nlp.entity.Value
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import kotlin.test.assertEquals
 
 /**
  *
@@ -30,8 +30,9 @@ class DateIntervalEntityValueDateSerializationTest {
     @Test
     fun testSerializeAndDeserialize() {
         val v = DateIntervalEntityValue(
-                DateEntityValue(ZonedDateTime.now(ZoneId.of("UTC")), DateEntityGrain.day),
-                DateEntityValue(ZonedDateTime.now(ZoneId.of("UTC")), DateEntityGrain.day))
+            DateEntityValue(ZonedDateTime.now(ZoneId.of("UTC")), DateEntityGrain.day),
+            DateEntityValue(ZonedDateTime.now(ZoneId.of("UTC")), DateEntityGrain.day)
+        )
         val s = mapper.writeValueAsString(v)
         assertEquals(v, mapper.readValue(s, Value::class.java))
     }

--- a/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateIntervalValueTest.kt
+++ b/nlp/entity-evaluator/entity-value/src/test/kotlin/fr/vsct/tock/nlp/entity/date/DateIntervalValueTest.kt
@@ -16,11 +16,11 @@
 
 package fr.vsct.tock.nlp.entity.date
 
-import org.junit.Assert
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.ZoneId
 import java.time.ZonedDateTime
+import kotlin.test.assertEquals
 
 /**
  *
@@ -32,6 +32,12 @@ class DateIntervalValueTest {
         val actual = ZonedDateTime.now()
         val duration = Duration.ofHours(2)
         val end = actual.plusHours(1).withZoneSameInstant(ZoneId.of("America/Phoenix"))
-        Assert.assertEquals(duration, DateIntervalEntityValue(DateEntityValue(actual, DateEntityGrain.hour), DateEntityValue(end, DateEntityGrain.hour)).duration())
+        assertEquals(
+            duration,
+            DateIntervalEntityValue(
+                DateEntityValue(actual, DateEntityGrain.hour),
+                DateEntityValue(end, DateEntityGrain.hour)
+            ).duration()
+        )
     }
 }

--- a/nlp/entity-evaluator/pom.xml
+++ b/nlp/entity-evaluator/pom.xml
@@ -37,12 +37,17 @@
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nlp/front/ioc/src/test/kotlin/fr/vsct/tock/nlp/front/ioc/FrontIocIntegrationTest.kt
+++ b/nlp/front/ioc/src/test/kotlin/fr/vsct/tock/nlp/front/ioc/FrontIocIntegrationTest.kt
@@ -21,8 +21,8 @@ import fr.vsct.tock.nlp.front.shared.codec.alexa.AlexaFilter
 import fr.vsct.tock.shared.defaultLocale
 import fr.vsct.tock.shared.jackson.mapper
 import fr.vsct.tock.shared.property
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.litote.kmongo.toId
 import java.io.File
 import java.util.Locale
@@ -37,7 +37,7 @@ class FrontIocIntegrationTest {
     val rootFile = File(property("test_export_dir", ""))
     val localeToExport = Locale.forLanguageTag(property("test_locale", defaultLocale.toLanguageTag()))
 
-    @Before
+    @BeforeEach
     fun before() {
         FrontIoc.setup()
     }
@@ -46,12 +46,13 @@ class FrontIocIntegrationTest {
     fun generateAlexaSchema() {
         val filterFile = File(rootFile, "alexa.json")
         val export = AlexaCodecService.exportIntentsSchema(
-                invocationName,
-                applicationId.toId(),
-                localeToExport,
-                if (filterFile.exists())
-                    mapper.readValue(filterFile, AlexaFilter::class.java)
-                else null)
+            invocationName,
+            applicationId.toId(),
+            localeToExport,
+            if (filterFile.exists())
+                mapper.readValue(filterFile, AlexaFilter::class.java)
+            else null
+        )
         mapper.writeValue(File(rootFile, "schema.json"), export)
     }
 

--- a/nlp/front/pom.xml
+++ b/nlp/front/pom.xml
@@ -49,12 +49,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/AbstractTest.kt
+++ b/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/AbstractTest.kt
@@ -39,8 +39,8 @@ import fr.vsct.tock.shared.injector
 import fr.vsct.tock.shared.name
 import fr.vsct.tock.shared.tockInternalInjector
 import io.mockk.mockk
-import org.junit.After
-import org.junit.Before
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.litote.kmongo.newId
 import org.litote.kmongo.toId
 import java.time.Instant
@@ -100,12 +100,12 @@ abstract class AbstractTest {
 
     val parseQuery = ParseQuery(emptyList(), namespace, appName, QueryContext(defaultLocale, Dice.newId()))
 
-    @Before
+    @BeforeEach
     fun initContext() {
         context.init()
     }
 
-    @After
+    @AfterEach
     fun cleanupContext() {
         tockInternalInjector = KodeinInjector()
     }

--- a/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/ApplicationCodecServiceTest.kt
+++ b/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/ApplicationCodecServiceTest.kt
@@ -25,9 +25,9 @@ import fr.vsct.tock.nlp.front.shared.config.ClassifiedSentenceStatus
 import fr.vsct.tock.nlp.front.shared.config.SentencesQueryResult
 import fr.vsct.tock.shared.defaultLocale
 import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import io.mockk.verify
-import org.junit.Before
-import org.junit.Test
 import org.litote.kmongo.toId
 import java.time.Instant.now
 import java.util.Locale
@@ -40,7 +40,7 @@ import kotlin.test.assertTrue
  */
 class ApplicationCodecServiceTest : AbstractTest() {
 
-    @Before
+    @BeforeEach
     fun before() {
         every { context.config.getApplicationByNamespaceAndName(any(), any()) } returns app
     }

--- a/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/FrontRepositoryTest.kt
+++ b/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/FrontRepositoryTest.kt
@@ -18,9 +18,9 @@ package fr.vsct.tock.nlp.front.service
 
 import fr.vsct.tock.nlp.front.shared.config.EntityTypeDefinition
 import io.mockk.every
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -33,12 +33,12 @@ class FrontRepositoryTest : AbstractTest() {
 
     val entityTypes = mutableListOf(EntityTypeDefinition("present"))
 
-    @Before
+    @BeforeEach
     fun before() {
         every { context.config.getEntityTypes() } returns entityTypes
     }
 
-    @After
+    @AfterEach
     fun after() {
         FrontRepository.entityTypes.clear()
     }

--- a/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/ParserRequestDataTest.kt
+++ b/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/ParserRequestDataTest.kt
@@ -18,7 +18,7 @@ package fr.vsct.tock.nlp.front.service
 
 import fr.vsct.tock.nlp.front.shared.parser.IntentQualifier
 import fr.vsct.tock.nlp.front.shared.parser.QueryState
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 
 /**
@@ -30,11 +30,11 @@ class ParserRequestDataTest : AbstractTest() {
     fun isStateEnabledForIntentId_shouldReturnTrue_whenIntentIsEnabledAndIntentSupportState() {
         val testState = "testState"
         val data = ParserRequestData(
-                app,
-                parseQuery.copy(state = QueryState(setOf(testState))),
-                defaultClassifiedSentence,
-                setOf(IntentQualifier(defaultIntentName, 0.2)),
-                listOf(defaultIntentDefinition)
+            app,
+            parseQuery.copy(state = QueryState(setOf(testState))),
+            defaultClassifiedSentence,
+            setOf(IntentQualifier(defaultIntentName, 0.2)),
+            listOf(defaultIntentDefinition)
         )
         assertTrue(data.isStateEnabledForIntentId(defaultIntentDefinition._id))
     }

--- a/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/ParserServiceTest.kt
+++ b/nlp/front/service/src/test/kotlin/fr/vsct/tock/nlp/front/service/ParserServiceTest.kt
@@ -23,7 +23,7 @@ import fr.vsct.tock.nlp.front.shared.config.ClassifiedSentenceStatus.model
 import fr.vsct.tock.nlp.front.shared.config.ClassifiedSentenceStatus.validated
 import fr.vsct.tock.shared.defaultLocale
 import io.mockk.verify
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.litote.kmongo.toId
 import java.util.Locale
 import kotlin.test.assertEquals
@@ -49,8 +49,8 @@ class ParserServiceTest : AbstractTest() {
     @Test
     fun findLanguage_shouldReturnDefault_WhenLocaleParameterIsNotSupportedAndDefaultIsSupported() {
         val locale = ParserService.findLanguage(
-                ApplicationDefinition("test", "test", supportedLocales = setOf(defaultLocale)),
-                Locale.JAPANESE
+            ApplicationDefinition("test", "test", supportedLocales = setOf(defaultLocale)),
+            Locale.JAPANESE
         )
 
         assertEquals(defaultLocale, locale)
@@ -59,14 +59,15 @@ class ParserServiceTest : AbstractTest() {
     @Test
     fun findLanguage_shouldReturnFirstFound_WhenLocaleParameterIsNotSupportedAndDefaultIsNotSupported() {
         val locale = ParserService.findLanguage(
-                ApplicationDefinition("test", "test", supportedLocales = setOf(Locale.ITALIAN)),
-                Locale.JAPANESE
+            ApplicationDefinition("test", "test", supportedLocales = setOf(Locale.ITALIAN)),
+            Locale.JAPANESE
         )
 
         assertEquals(Locale.ITALIAN, locale)
     }
 
-    private val validatedSentence = defaultClassifiedSentence.copy(classification = defaultClassification.copy("new_intent".toId()))
+    private val validatedSentence =
+        defaultClassifiedSentence.copy(classification = defaultClassification.copy("new_intent".toId()))
 
 
     @Test

--- a/nlp/integration-tests/pom.xml
+++ b/nlp/integration-tests/pom.xml
@@ -51,12 +51,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/nlp/integration-tests/src/test/kotlin/fr/vsct/tock/nlp/integration/IntegrationTest.kt
+++ b/nlp/integration-tests/src/test/kotlin/fr/vsct/tock/nlp/integration/IntegrationTest.kt
@@ -27,8 +27,8 @@ import fr.vsct.tock.nlp.front.shared.parser.ParsedEntityValue
 import fr.vsct.tock.nlp.front.shared.parser.QueryContext
 import fr.vsct.tock.shared.defaultNamespace
 import fr.vsct.tock.shared.defaultZoneId
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 import java.util.Locale
 import kotlin.test.assertEquals
@@ -39,7 +39,8 @@ import kotlin.test.assertEquals
 class IntegrationTest {
 
     companion object {
-        @BeforeClass @JvmStatic
+        @BeforeAll
+        @JvmStatic
         fun beforeClass() {
             IntegrationConfiguration.init(NlpEngineType.opennlp)
         }
@@ -47,15 +48,37 @@ class IntegrationTest {
 
     @Test
     fun testOpenNlpSimpleRequest() {
-        val result = FrontClient.parse(ParseQuery(listOf("I want to go to Paris tomorrow"), defaultNamespace, "test", QueryContext(Locale.ENGLISH, "clientTest")))
+        val result = FrontClient.parse(
+            ParseQuery(
+                listOf("I want to go to Paris tomorrow"),
+                defaultNamespace,
+                "test",
+                QueryContext(Locale.ENGLISH, "clientTest")
+            )
+        )
         println(result)
         assertEquals("travel", result.intent)
         assertEquals(2, result.entities.size)
-        assertEquals(ParsedEntityValue(16, 21, Entity(EntityType("$defaultNamespace:locality"), "locality"), null, probability = 0.30666386016073854), result.firstValue("locality"))
-        assertEquals(ParsedEntityValue(22, 30, Entity(EntityType("duckling:datetime"), "datetime"),
+        assertEquals(
+            ParsedEntityValue(
+                16,
+                21,
+                Entity(EntityType("$defaultNamespace:locality"), "locality"),
+                null,
+                probability = 0.30666386016073854
+            ), result.firstValue("locality")
+        )
+        assertEquals(
+            ParsedEntityValue(
+                22, 30, Entity(EntityType("duckling:datetime"), "datetime"),
                 DateEntityValue(
-                        ZonedDateTime.now().withZoneSameInstant(defaultZoneId).plusDays(1).withHour(0).withMinute(0).withSecond(0).withNano(0).withFixedOffsetZone(),
-                        DateEntityGrain.day), true, probability = 0.6447195532270447, mergeSupport = true), result.firstValue("datetime"))
+                    ZonedDateTime.now().withZoneSameInstant(defaultZoneId).plusDays(1).withHour(0).withMinute(0).withSecond(
+                        0
+                    ).withNano(0).withFixedOffsetZone(),
+                    DateEntityGrain.day
+                ), true, probability = 0.6447195532270447, mergeSupport = true
+            ), result.firstValue("datetime")
+        )
 
 
     }

--- a/nlp/model/opennlp/src/test/kotlin/fr/vsct/tock/nlp/opennlp/OpenNlpEntityClassifierTest.kt
+++ b/nlp/model/opennlp/src/test/kotlin/fr/vsct/tock/nlp/opennlp/OpenNlpEntityClassifierTest.kt
@@ -29,7 +29,7 @@ import io.mockk.every
 import io.mockk.mockk
 import opennlp.tools.namefind.NameFinderME
 import opennlp.tools.util.Span
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 import kotlin.test.assertEquals
 
@@ -42,15 +42,16 @@ class OpenNlpEntityClassifierTest {
     fun classify_withAdjacentEntitiesOfSameRole_shouldMergeEntities() {
         val entity = Entity(EntityType("test:test"), "test")
         val context = EntityCallContextForIntent(
-                "test",
-                Intent("test", listOf(entity)),
-                defaultLocale,
-                NlpEngineType.opennlp,
-                ZonedDateTime.now())
+            "test",
+            Intent("test", listOf(entity)),
+            defaultLocale,
+            NlpEngineType.opennlp,
+            ZonedDateTime.now()
+        )
         val text = "a b"
         val tokens = arrayOf("a", "b")
         val model: NameFinderME = mockk()
-        every { model.find(eq(tokens)) } answers  { arrayOf(Span(0, 1, "test", 0.8), Span(1, 2, "test", 0.6)) }
+        every { model.find(eq(tokens)) } answers { arrayOf(Span(0, 1, "test", 0.8), Span(1, 2, "test", 0.6)) }
 
         val classifier = OpenNlpEntityClassifier(EntityModelHolder(model))
 
@@ -64,15 +65,16 @@ class OpenNlpEntityClassifierTest {
     fun classify_withAdjacentMultiTokensEntitiesOfSameRole_shouldMergeEntities() {
         val entity = Entity(EntityType("test:test"), "test")
         val context = EntityCallContextForIntent(
-                "test",
-                Intent("test", listOf(entity)),
-                defaultLocale,
-                NlpEngineType.opennlp,
-                ZonedDateTime.now())
+            "test",
+            Intent("test", listOf(entity)),
+            defaultLocale,
+            NlpEngineType.opennlp,
+            ZonedDateTime.now()
+        )
         val text = "a a b"
         val tokens = arrayOf("a", "a", "b")
         val model: NameFinderME = mockk()
-        every { model.find(eq(tokens))} answers { arrayOf(Span(0, 2, "test", 0.8), Span(2, 3, "test", 0.6)) }
+        every { model.find(eq(tokens)) } answers { arrayOf(Span(0, 2, "test", 0.8), Span(2, 3, "test", 0.6)) }
 
         val classifier = OpenNlpEntityClassifier(EntityModelHolder(model))
 
@@ -86,11 +88,12 @@ class OpenNlpEntityClassifierTest {
     fun classify_withNotAdjacentEntitiesOfSameRole_shouldReturnsTwoEntities() {
         val entity = Entity(EntityType("test:test"), "test")
         val context = EntityCallContextForIntent(
-                "test",
-                Intent("test", listOf(entity)),
-                defaultLocale,
-                NlpEngineType.opennlp,
-                ZonedDateTime.now())
+            "test",
+            Intent("test", listOf(entity)),
+            defaultLocale,
+            NlpEngineType.opennlp,
+            ZonedDateTime.now()
+        )
         val text = "a toto b"
         val tokens = arrayOf("a", "toto", "b")
         val model: NameFinderME = mockk()
@@ -102,9 +105,10 @@ class OpenNlpEntityClassifierTest {
 
         println(result)
         assertEquals(
-                listOf(
-                        EntityRecognition(EntityValue(0, 1, entity), 0.8),
-                        EntityRecognition(EntityValue(7, 8, entity), 0.6)
-                ), result)
+            listOf(
+                EntityRecognition(EntityValue(0, 1, entity), 0.8),
+                EntityRecognition(EntityValue(7, 8, entity), 0.6)
+            ), result
+        )
     }
 }

--- a/nlp/model/opennlp/src/test/kotlin/fr/vsct/tock/nlp/opennlp/OpenNlpTokenizerTest.kt
+++ b/nlp/model/opennlp/src/test/kotlin/fr/vsct/tock/nlp/opennlp/OpenNlpTokenizerTest.kt
@@ -19,8 +19,7 @@ package fr.vsct.tock.nlp.opennlp
 import fr.vsct.tock.nlp.core.NlpEngineType
 import fr.vsct.tock.nlp.model.TokenizerContext
 import fr.vsct.tock.nlp.model.service.engine.TokenizerModelHolder
-import fr.vsct.tock.nlp.opennlp.OpenNlpTokenizer
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.Locale
 import kotlin.test.assertEquals
 

--- a/nlp/model/pom.xml
+++ b/nlp/model/pom.xml
@@ -45,12 +45,17 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,12 @@
         <commons-codec>1.11</commons-codec>
         <commons-lang>3.7</commons-lang>
 
-        <junit>4.12</junit>
+        <junit-platform>1.1.0</junit-platform>
+        <junit-jupiter>5.1.0</junit-jupiter>
         <mockito-kotlin>1.5.0</mockito-kotlin>
         <mockk>1.7.10</mockk>
 
-        <plugin.surefire>2.21.0</plugin.surefire>
+        <plugin.surefire>2.19.1</plugin.surefire>
         <plugin.source>3.0.1</plugin.source>
         <plugin.release>2.5.3</plugin.release>
         <plugin.gpg>1.6</plugin.gpg>
@@ -354,14 +355,20 @@
             </dependency>
 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit}</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit-jupiter}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-test-junit</artifactId>
+                <artifactId>kotlin-test</artifactId>
                 <version>${kotlin}</version>
                 <scope>test</scope>
             </dependency>
@@ -411,6 +418,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${plugin.surefire}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${junit-platform}</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <includes>
                         <include>**/*Test.*</include>
@@ -420,7 +434,6 @@
                     <excludes>
                         <exclude>**/*IntegrationTest.*</exclude>
                     </excludes>
-
                 </configuration>
             </plugin>
             <plugin>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -117,7 +117,7 @@
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -126,8 +126,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/DiceTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/DiceTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.shared
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 
 /**
@@ -27,7 +27,7 @@ class DiceTest {
     @Test
     fun newId_ShouldReturnAtLeats23CharsAndAtMost24() {
         Dice.newId().apply {
-            assertTrue(length >= 23 && length <= 24)
+            assertTrue(length in 23..24)
         }
     }
 }

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/EncryptorTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/EncryptorTest.kt
@@ -18,7 +18,7 @@ package fr.vsct.tock.shared
 
 import fr.vsct.tock.shared.security.decrypt
 import fr.vsct.tock.shared.security.encrypt
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.security.SecureRandom
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/MongoTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/MongoTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.shared
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/StringsTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/StringsTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.shared
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue
 
 /**

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/VertxTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/VertxTest.kt
@@ -20,7 +20,7 @@ import fr.vsct.tock.shared.vertx.defaultVertxOptions
 import fr.vsct.tock.shared.vertx.vertx
 import io.vertx.core.VertxOptions
 import io.vertx.core.impl.VertxInternal
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.util.concurrent.ThreadPoolExecutor
 import kotlin.test.assertEquals
 

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/jackson/AnyValueWrapperTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/jackson/AnyValueWrapperTest.kt
@@ -18,7 +18,7 @@ package fr.vsct.tock.shared.jackson
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/security/SimpleObfuscatorTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/security/SimpleObfuscatorTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.shared.security
 
 import fr.vsct.tock.shared.security.StringObfuscatorMode.display
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 

--- a/shared/src/test/kotlin/fr/vsct/tock/shared/security/StringObfuscatorServiceTest.kt
+++ b/shared/src/test/kotlin/fr/vsct/tock/shared/security/StringObfuscatorServiceTest.kt
@@ -18,9 +18,9 @@ package fr.vsct.tock.shared.security
 
 import fr.vsct.tock.shared.security.StringObfuscatorMode.display
 import fr.vsct.tock.shared.security.StringObfuscatorService.obfuscate
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 
@@ -29,12 +29,12 @@ import kotlin.test.assertEquals
  */
 class StringObfuscatorServiceTest {
 
-    @Before
+    @BeforeEach
     fun before() {
         StringObfuscatorService.registerObfuscator(SimpleObfuscator("\\d{9}".toRegex(), "sososecret", "?"))
     }
 
-    @After
+    @AfterEach
     fun after() {
         StringObfuscatorService.deregisterObfuscators()
     }

--- a/translator/core/src/test/kotlin/fr/vsct/tock/translator/AbstractTest.kt
+++ b/translator/core/src/test/kotlin/fr/vsct/tock/translator/AbstractTest.kt
@@ -22,8 +22,8 @@ import com.github.salomonbrys.kodein.bind
 import com.github.salomonbrys.kodein.provider
 import fr.vsct.tock.shared.tockInternalInjector
 import io.mockk.mockk
-import org.junit.After
-import org.junit.Before
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 
 /**
  *
@@ -40,7 +40,7 @@ abstract class AbstractTest {
         }
     }
 
-    @Before
+    @BeforeEach
     fun initContext() {
         tockInternalInjector = KodeinInjector()
         tockInternalInjector.inject(Kodein {
@@ -49,7 +49,7 @@ abstract class AbstractTest {
         Translator.enabled = true
     }
 
-    @After
+    @AfterEach
     fun cleanupContext() {
         tockInternalInjector = KodeinInjector()
         Translator.enabled = false

--- a/translator/core/src/test/kotlin/fr/vsct/tock/translator/DateTemplateTest.kt
+++ b/translator/core/src/test/kotlin/fr/vsct/tock/translator/DateTemplateTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.translator
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.LocalDate.now
 import java.util.Formatter
@@ -35,14 +35,14 @@ class DateTemplateTest {
         var formatter = Formatter(Locale.ENGLISH)
         dateTemplate.formatTo(formatter, 0, 0, 0)
         assertEquals(
-                "Friday",
-                formatter.toString()
+            "Friday",
+            formatter.toString()
         )
         formatter = Formatter(Locale.FRENCH)
         dateTemplate.formatTo(formatter, 0, 0, 0)
         assertEquals(
-                "vendredi",
-                formatter.toString()
+            "vendredi",
+            formatter.toString()
         )
     }
 

--- a/translator/core/src/test/kotlin/fr/vsct/tock/translator/I18nLabelLocalizedTest.kt
+++ b/translator/core/src/test/kotlin/fr/vsct/tock/translator/I18nLabelLocalizedTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.translator
 
 import fr.vsct.tock.shared.defaultLocale
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**

--- a/translator/core/src/test/kotlin/fr/vsct/tock/translator/I18nLabelTest.kt
+++ b/translator/core/src/test/kotlin/fr/vsct/tock/translator/I18nLabelTest.kt
@@ -17,7 +17,7 @@
 package fr.vsct.tock.translator
 
 import fr.vsct.tock.shared.defaultNamespace
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.litote.kmongo.toId
 import java.util.Locale
 import kotlin.test.assertNotNull

--- a/translator/core/src/test/kotlin/fr/vsct/tock/translator/I18nTest.kt
+++ b/translator/core/src/test/kotlin/fr/vsct/tock/translator/I18nTest.kt
@@ -16,7 +16,7 @@
 
 package fr.vsct.tock.translator
 
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -33,12 +33,12 @@ class I18nTest {
         val date = LocalDate.now().with(DayOfWeek.FRIDAY)
         val format = DateTimeFormatter.ofPattern("EEEE")
         assertEquals(
-                "Friday",
-                date.formatWith(format, Locale.ENGLISH).toString()
+            "Friday",
+            date.formatWith(format, Locale.ENGLISH).toString()
         )
         assertEquals(
-                "vendredi",
-                date.formatWith(format, Locale.FRENCH).toString()
+            "vendredi",
+            date.formatWith(format, Locale.FRENCH).toString()
         )
     }
 }

--- a/translator/core/src/test/kotlin/fr/vsct/tock/translator/TextAndVoiceTranslatedStringTest.kt
+++ b/translator/core/src/test/kotlin/fr/vsct/tock/translator/TextAndVoiceTranslatedStringTest.kt
@@ -16,8 +16,8 @@
 
 package fr.vsct.tock.translator
 
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 /**
  *

--- a/translator/core/src/test/kotlin/fr/vsct/tock/translator/TranslatorTest.kt
+++ b/translator/core/src/test/kotlin/fr/vsct/tock/translator/TranslatorTest.kt
@@ -21,7 +21,7 @@ import fr.vsct.tock.shared.defaultNamespace
 import fr.vsct.tock.translator.UserInterfaceType.textChat
 import io.mockk.every
 import io.mockk.verify
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.litote.kmongo.toId
 import kotlin.test.assertEquals
 

--- a/translator/pom.xml
+++ b/translator/pom.xml
@@ -37,12 +37,17 @@
     <dependencies>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
+            <artifactId>kotlin-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
I converted the entire project to use [JUnit 5](https://junit.org/junit5/docs/current/user-guide/#overview) with the [kotlin-test](https://kotlinlang.org/api/latest/kotlin.test/index.html) assertion library. I also provided a [JUnit 5 Extension](https://github.com/lith-light-g/tock/blob/master/bot/test/src/main/kotlin/fr/vsct/tock/bot/test/junit/TockJUnit5Extension.kt) in order to replace the previous [rule](https://github.com/lith-light-g/tock/blob/master/bot/test/src/main/kotlin/fr/vsct/tock/bot/test/junit/TockJUnit4Rule.kt) we had (the previous rule is still in the project).