### PR TITLE
trigger word are not mandatory anymore and the bot can't answer bots messages

### DIFF
--- a/bot/connector-slack/src/main/kotlin/fr/vsct/tock/bot/connector/slack/SlackConnector.kt
+++ b/bot/connector-slack/src/main/kotlin/fr/vsct/tock/bot/connector/slack/SlackConnector.kt
@@ -56,19 +56,21 @@ class SlackConnector(val applicationId: String,
                     val body = context.convertUrlEncodedStringToJson()
                     logger.info { "message received from slack: $body" }
                     val message = mapper.readValue<SlackMessageIn>(body, SlackMessageIn::class.java)
-
-                    vertx.executeBlocking<Void>({
-                        try {
-                            val event = SlackRequestConverter.toEvent(message, applicationId)
-                            if (event != null) {
-                                controller.handle(event)
-                            } else {
-                                logger.logError("unable to convert $message to event", requestTimerData)
+                    if(message.user_id != "USLACKBOT")
+                    {
+                        vertx.executeBlocking<Void>({
+                            try {
+                                val event = SlackRequestConverter.toEvent(message, applicationId)
+                                if (event != null) {
+                                    controller.handle(event)
+                                } else {
+                                    logger.logError("unable to convert $message to event", requestTimerData)
+                                }
+                            } catch (e: Throwable) {
+                                logger.logError(e, requestTimerData)
                             }
-                        } catch (e: Throwable) {
-                            logger.logError(e, requestTimerData)
-                        }
-                    }, false, {})
+                        }, false, {})
+                    }
                 } catch (e: Throwable) {
                     logger.logError(e, requestTimerData)
                 } finally {

--- a/bot/connector-slack/src/main/kotlin/fr/vsct/tock/bot/connector/slack/model/SlackMessageIn.kt
+++ b/bot/connector-slack/src/main/kotlin/fr/vsct/tock/bot/connector/slack/model/SlackMessageIn.kt
@@ -29,7 +29,7 @@ data class SlackMessageIn(
     val user_id: String,
     val user_name: String,
     var text: String,
-    val trigger_word: String
+    val trigger_word: String?
 ) : SlackConnectorMessage() {
 
     fun getRealMessage(): String {


### PR DESCRIPTION
Changed the trigger_word type to a nullable to make the bot able to receive messages without trigger_word.
Added a condition so the bot can't answer a message from a bot.