### PR TITLE
Connected Rocketchat Connector to Livechat

### DIFF
--- a/bot/connector-rocketchat/pom.xml
+++ b/bot/connector-rocketchat/pom.xml
@@ -28,6 +28,10 @@
     <name>Tock Bot Rocket Chat Connector</name>
     <description>Bot Connector for Rocket Chat</description>
 
+    <properties>
+        <kotlin.version>1.2.71</kotlin.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>fr.vsct.tock</groupId>
@@ -81,6 +85,47 @@
             <version>${vertx}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>1.8</jvmTarget>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/bot/connector-rocketchat/src/main/kotlin/RocketChatClient.kt
+++ b/bot/connector-rocketchat/src/main/kotlin/RocketChatClient.kt
@@ -23,6 +23,7 @@ import chat.rocket.core.TokenRepository
 import chat.rocket.core.internal.realtime.socket.connect
 import chat.rocket.core.internal.realtime.socket.model.State
 import chat.rocket.core.internal.realtime.subscribeRooms
+import chat.rocket.core.internal.rest.getInfo
 import chat.rocket.core.internal.rest.joinChat
 import chat.rocket.core.internal.rest.login
 import chat.rocket.core.internal.rest.sendMessage
@@ -118,7 +119,6 @@ internal class RocketChatClient(
                     }
                     logger.debug("Done on statusChannel")
                 }
-
                 launch {
                     for (room in client.roomsChannel) {
                         listener.invoke(room.data)
@@ -151,7 +151,7 @@ internal class RocketChatClient(
                     message = message,
                     alias = "Tock bot",
                     emoji = ":smirk:",
-                    avatar = "https://avatars2.githubusercontent.com/u/224255?s=88&v=4"
+                    avatar = "https://images.discordapp.net/avatars/348187123536494592/32c74035bac6fb7636c12d51130e846f.png?size=64"
                 )
             } catch (e: Exception) {
                 logger.error(e)

--- a/bot/connector-rocketchat/src/main/kotlin/RocketChatClient.kt
+++ b/bot/connector-rocketchat/src/main/kotlin/RocketChatClient.kt
@@ -45,7 +45,8 @@ import java.util.concurrent.TimeUnit
 internal class RocketChatClient(
     private val targetUrl: String,
     val login: String,
-    private val password: String
+    private val password: String,
+    private val avatar: String
 ) {
 
     companion object {
@@ -95,7 +96,7 @@ internal class RocketChatClient(
         }
     }
 
-    fun join(roomId: String, listener: (Room) -> Unit) {
+    fun join(listener: (Room) -> Unit) {
         val job = launch(CommonPool) {
             try {
                 logger.debug { "Try to connect $login" }
@@ -126,8 +127,6 @@ internal class RocketChatClient(
                 }
 
                 client.connect()
-
-                client.joinChat(roomId)
             } catch (e: Exception) {
                 logger.error(e)
             }
@@ -151,7 +150,7 @@ internal class RocketChatClient(
                     message = message,
                     alias = "Tock bot",
                     emoji = ":smirk:",
-                    avatar = "https://images.discordapp.net/avatars/348187123536494592/32c74035bac6fb7636c12d51130e846f.png?size=64"
+                    avatar = avatar
                 )
             } catch (e: Exception) {
                 logger.error(e)

--- a/bot/connector-rocketchat/src/main/kotlin/RocketChatConnector.kt
+++ b/bot/connector-rocketchat/src/main/kotlin/RocketChatConnector.kt
@@ -16,6 +16,7 @@
 
 package fr.vsct.tock.bot.connector.rocketchat
 
+import chat.rocket.common.model.roomTypeOf
 import fr.vsct.tock.bot.connector.ConnectorBase
 import fr.vsct.tock.bot.connector.ConnectorCallback
 import fr.vsct.tock.bot.engine.BotRepository
@@ -50,11 +51,12 @@ internal class RocketChatConnector(
             } else {
                 val requestTimerData = BotRepository.requestTimer.start("rocketchat_webhook")
                 try {
+                    logger.debug { "To NLP from ${room.lastMessage!!.roomId}" }
                     controller.handle(
                         SendSentence(
                             PlayerId(room.lastMessage!!.sender!!.id!!),
                             applicationId,
-                            PlayerId("bot", PlayerType.bot),
+                            PlayerId("bot:"+room.lastMessage!!.roomId!!, PlayerType.bot),
                             room.lastMessage!!.message
                         )
                     )
@@ -72,8 +74,10 @@ internal class RocketChatConnector(
     }
 
     override fun send(event: Event, callback: ConnectorCallback, delayInMs: Long) {
+        logger.debug { "I've got a ${event::class.qualifiedName}" }
         if (event is SendSentence && event.text != null) {
-            client.send(roomId, event.stringText!!)
+            logger.debug { "Time to send ! $event  to ${event.playerId.id.substring(4)}" }
+            client.send(event.playerId.id.substring(4), event.stringText!!)
         }
     }
 }

--- a/bot/connector-rocketchat/src/main/kotlin/RocketChatConnector.kt
+++ b/bot/connector-rocketchat/src/main/kotlin/RocketChatConnector.kt
@@ -51,7 +51,6 @@ internal class RocketChatConnector(
             } else {
                 val requestTimerData = BotRepository.requestTimer.start("rocketchat_webhook")
                 try {
-                    logger.debug { "To NLP from ${room.lastMessage!!.roomId}" }
                     controller.handle(
                         SendSentence(
                             PlayerId(room.lastMessage!!.sender!!.id!!),
@@ -74,9 +73,7 @@ internal class RocketChatConnector(
     }
 
     override fun send(event: Event, callback: ConnectorCallback, delayInMs: Long) {
-        logger.debug { "I've got a ${event::class.qualifiedName}" }
         if (event is SendSentence && event.text != null) {
-            logger.debug { "Time to send ! $event  to ${event.playerId.id.substring(4)}" }
             client.send(event.playerId.id.substring(4), event.stringText!!)
         }
     }

--- a/bot/connector-rocketchat/src/main/kotlin/RocketChatConnectorProvider.kt
+++ b/bot/connector-rocketchat/src/main/kotlin/RocketChatConnectorProvider.kt
@@ -30,9 +30,9 @@ import fr.vsct.tock.shared.resourceAsString
 internal object RocketChatConnectorProvider : ConnectorProvider {
 
     private const val ROCKET_CHAT_URL = "_url_"
-    private const val ROOM_ID = "_room_id_"
     private const val LOGIN = "_login_"
     private const val PASSWORD = "_password_"
+    private const val AVATAR = "_avatar_"
 
     override val connectorType: ConnectorType get() = rocketChatConnectorType
 
@@ -40,11 +40,11 @@ internal object RocketChatConnectorProvider : ConnectorProvider {
         with(connectorConfiguration) {
             return RocketChatConnector(
                 connectorId,
-                parameters.getValue(ROOM_ID),
                 RocketChatClient(
                     parameters.getValue(ROCKET_CHAT_URL),
                     parameters.getValue(LOGIN),
-                    parameters.getValue(PASSWORD)
+                    parameters.getValue(PASSWORD),
+                    parameters.getValue(AVATAR)
                 )
             )
         }
@@ -60,11 +60,6 @@ internal object RocketChatConnectorProvider : ConnectorProvider {
                     true
                 ),
                 ConnectorTypeConfigurationField(
-                    "Room Id",
-                    ROOM_ID,
-                    true
-                ),
-                ConnectorTypeConfigurationField(
                     "Bot Login",
                     LOGIN,
                     true
@@ -72,6 +67,11 @@ internal object RocketChatConnectorProvider : ConnectorProvider {
                 ConnectorTypeConfigurationField(
                     "Bot Password",
                     PASSWORD,
+                    true
+                ),
+                ConnectorTypeConfigurationField(
+                    "Avatar Url",
+                    AVATAR,
                     true
                 )
             ),


### PR DESCRIPTION
With this the connector will : 
 - no longer need a RoomId to work
 - answer each message in its appropriate channel (before it would answer all messages in the preconfigured room, despite them being send from another room)
 - no longer answer messages from classic rooms, only livechat rooms