### PR TITLE
truncate label and description quick replies for twitter connector

### DIFF
--- a/bot/connector-twitter/src/main/kotlin/fr/vsct/tock/bot/connector/twitter/TwitterBuilders.kt
+++ b/bot/connector-twitter/src/main/kotlin/fr/vsct/tock/bot/connector/twitter/TwitterBuilders.kt
@@ -43,6 +43,16 @@ internal const val TWITTER_CONNECTOR_TYPE_ID = "twitter"
  */
 val twitterConnectorType = ConnectorType(TWITTER_CONNECTOR_TYPE_ID)
 
+const val maxOptionLabel = 36
+const val maxOptionDescription = 72
+const val maxMetadata = 1000
+
+fun CharSequence.truncateIfLongerThan(maxCharacter: Int): String =
+    if(maxCharacter >= 0 && this.length > maxCharacter) {
+        if(maxCharacter > 3) this.substring(0, maxCharacter - 3) + "..."
+        else this.substring(0, maxCharacter)
+    }
+    else this.toString()
 
 /**
  * Creates a direct message with only text
@@ -131,8 +141,9 @@ fun BotBus.webUrl(
     url: CharSequence
 ): WebUrl {
     val l = translate(label)
-    if (l.length > 36) {
-        logger.warn { "label $l has more than 36 chars" }
+    if (l.length > maxOptionLabel) {
+        logger.warn { "label $l has more than $maxOptionLabel chars, it will be truncated" }
+        return WebUrl(l.truncateIfLongerThan(maxOptionLabel), url.toString())
     }
     return WebUrl(l.toString(), url.toString())
 }
@@ -178,18 +189,18 @@ private fun BotBus.option(
     metadataEncoder: (IntentAware, StoryStep<out StoryHandlerDefinition>?, Map<String, String>) -> String
 ): Option {
     val l = translate(label)
-    if (l.length > 36) {
-        logger.warn { "label $l has more than 36 chars" }
+    if (l.length > maxOptionLabel) {
+        logger.warn { "label $l has more than $maxOptionLabel chars, it will be truncated" }
     }
     val d = translate(description)
-    if (d.length > 72) {
-        logger.warn { "label $d has more than 72 chars" }
+    if (d.length > maxOptionDescription) {
+        logger.warn { "label $d has more than $maxOptionDescription chars, it will be truncated" }
     }
     val metadata = metadataEncoder.invoke(targetIntent, step, parameters)
-    if (metadata.length > 1000) {
-        logger.warn { "payload $metadata has more than 1000 chars" }
+    if (metadata.length > maxMetadata) {
+        logger.warn { "payload $metadata has more than $maxMetadata chars, it will be truncated" }
     }
-    return Option(l.toString(), d.toString(), metadata)
+    return Option(l.truncateIfLongerThan(maxOptionLabel), d.truncateIfLongerThan(maxOptionDescription), metadata.truncateIfLongerThan(maxMetadata))
 }
 
 /**

--- a/bot/connector-twitter/src/test/kotlin/fr/vsct/tock/bot/connector/twitter/TwitterBuildersTest.kt
+++ b/bot/connector-twitter/src/test/kotlin/fr/vsct/tock/bot/connector/twitter/TwitterBuildersTest.kt
@@ -26,6 +26,8 @@ import fr.vsct.tock.shared.tockInternalInjector
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
 
 class TwitterBuildersTest {
 
@@ -47,4 +49,38 @@ class TwitterBuildersTest {
         every { bus.translate(allAny()) } answers { firstArg() ?: "" }
     }
 
+    @Test
+    fun `strip dots lesser for twitter`() {
+        val givenStringLesserThan: CharSequence = "String Text"
+
+        assertEquals("String Text", givenStringLesserThan.truncateIfLongerThan(12))
+        assertEquals("", givenStringLesserThan.truncateIfLongerThan(0))
+        assertEquals("S", givenStringLesserThan.truncateIfLongerThan(1))
+        assertEquals("St", givenStringLesserThan.truncateIfLongerThan(2))
+        assertEquals("Str", givenStringLesserThan.truncateIfLongerThan(3))
+        assertEquals("S...", givenStringLesserThan.truncateIfLongerThan(4))
+        assertEquals("String Text", givenStringLesserThan.truncateIfLongerThan(-1))
+    }
+
+    @Test
+    fun `strip dots longer for twitter`() {
+        val givenStringMoreThan: CharSequence = "String Text 1 String Text 1"
+
+        assertEquals("String T...", givenStringMoreThan.truncateIfLongerThan(11))
+    }
+
+    @Test
+    fun `strip dots for twitter empty`() {
+        val givenStringEmpty: CharSequence = ""
+
+        assertEquals("", givenStringEmpty.truncateIfLongerThan(11))
+    }
+
+    @Test
+    fun `no strip dots for twitter equal`() {
+        val givenStringEqual: CharSequence = "String Text"
+
+        assertEquals("String Text", givenStringEqual.truncateIfLongerThan(11))
+
+    }
 }


### PR DESCRIPTION
Truncate to not fail into some unwanted errors.