### PR TITLE
Alexa Connector - Fix intent name with suffix

### DIFF
--- a/bot/connector-alexa/src/main/kotlin/fr/vsct/tock/bot/connector/alexa/AlexaTockMapper.kt
+++ b/bot/connector-alexa/src/main/kotlin/fr/vsct/tock/bot/connector/alexa/AlexaTockMapper.kt
@@ -47,7 +47,7 @@ open class AlexaTockMapper(val applicationId: String) {
     open fun alexaIntentToTockIntent(request: IntentRequest, botDefinition: BotDefinition): String {
         val intentName = request.intent.name
         return if (intentName.endsWith("_intent")) {
-            intentName.substring(0, "_intent".length)
+            intentName.substring(0, intentName.length - "_intent".length)
         } else {
             intentName
         }


### PR DESCRIPTION
Fix incorrect substring on the intent name in AlexaTockMapper.