### PR TITLE
add business chat connector

### DIFF
--- a/bot/connector-businesschat/pom.xml
+++ b/bot/connector-businesschat/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tock-bot</artifactId>
+        <groupId>fr.vsct.tock</groupId>
+        <version>19.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>tock-bot-connector-businesschat</artifactId>
+    <name>Tock Bot business chat Connector</name>
+    <description>Bot Connector for business chat</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.vsct.tock</groupId>
+            <artifactId>tock-bot-engine</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatBuilder.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatBuilder.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat
+
+import fr.vsct.tock.bot.connector.ConnectorMessage
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorImageMessage
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorMessage
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorTextMessage
+import fr.vsct.tock.bot.engine.BotBus
+
+/**
+ * Adds a Business Chat [ConnectorMessage] if the current connector is Business Chat.
+ * You need to call [BotBus.send] or [BotBus.end] later to send this message.
+ */
+fun BotBus.withBusinessChat(messageProvider: () -> BusinessChatConnectorMessage): BotBus {
+    return withMessage(businessChatConnectorType, messageProvider)
+}
+
+/**
+ * Creates a [BusinessChatText].
+ *
+ * @param text the text sent
+ *
+ */
+fun BotBus.businessChatText(
+    text: String
+): BusinessChatConnectorMessage =
+        BusinessChatConnectorTextMessage(
+                sourceId = botId.id,
+                destinationId = userId.id,
+                body = translate(text).toString()
+        )
+
+/**
+ * Creates a [BusinessChatConnectorImageMessage]
+ *
+ * @param attachment an array of bytes containing an image
+ * @param mimeType the mime type of the image, which is image/png by default
+ */
+fun BotBus.businessChatAttachement(
+        attachment: ByteArray,
+        mimeType: String = "image/png"
+): BusinessChatConnectorMessage =
+        BusinessChatConnectorImageMessage(
+                sourceId = botId.id,
+                destinationId = userId.id,
+                bytes = attachment,
+                mimeType = mimeType
+        )

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatConnector.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatConnector.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import fr.vsct.tock.bot.connector.ConnectorBase
+import fr.vsct.tock.bot.connector.ConnectorCallback
+import fr.vsct.tock.bot.connector.ConnectorData
+import fr.vsct.tock.bot.connector.businesschat.model.csp.message.Message
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorImageMessage
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorTextMessage
+import fr.vsct.tock.bot.engine.BotRepository
+import fr.vsct.tock.bot.engine.ConnectorController
+import fr.vsct.tock.bot.engine.action.SendSentence
+import fr.vsct.tock.bot.engine.event.Event
+import fr.vsct.tock.bot.engine.monitoring.logError
+import fr.vsct.tock.shared.error
+import fr.vsct.tock.shared.injector
+import fr.vsct.tock.shared.jackson.mapper
+import fr.vsct.tock.shared.provide
+import mu.KotlinLogging
+
+/**
+ * Defines a connector for BusinessChat
+ * @param path base path for our business chat endpoints
+ * @param businessId your organization Business ID
+ */
+class BusinessChatConnector(private val path: String, private val connectorId: String, private val businessId: String) :
+        ConnectorBase(BusinessChatConnectorProvider.connectorType) {
+
+    private val logger = KotlinLogging.logger { }
+    private val cspBusinessChatClient: CSPBusinessChatClient get() = injector.provide()
+
+    /**
+     * Called for each messages sent on the bot bus
+     */
+    override fun send(event: Event, callback: ConnectorCallback, delayInMs: Long) {
+        when (event) {
+            is SendSentence -> {
+                val message = MessageConverter.toMessage(event)
+                if (message is BusinessChatConnectorTextMessage) {
+                    cspBusinessChatClient.sendMessage(message)
+                } else if (message is BusinessChatConnectorImageMessage) {
+                    cspBusinessChatClient.sendAttachment(message)
+                }
+            }
+        }
+    }
+
+    /**
+     * Defines an endpoint for receiving business chat notifications
+     */
+    override fun register(controller: ConnectorController) {
+        controller.registerServices(path) { router ->
+            router.post(path).handler { context ->
+                val requestTimerData = BotRepository.requestTimer.start("business chat start")
+                try {
+                    val body = context.bodyAsString
+                    val message = mapper.readValue<Message>(body)
+
+                    when (businessId) {
+                        message.sourceId -> {
+                            logger.info("Ignoring echo message")
+                        }
+                        else -> {
+                            val event = MessageConverter.toEvent(message, connectorId)
+                            event?.let {
+                                when (it) {
+                                    is SendSentence -> {
+                                        controller.handle(
+                                                event,
+                                                ConnectorData(
+                                                        BusinessChatConnectorCallback(connectorId)
+                                                )
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                } catch (e: Exception) {
+                    BotRepository.requestTimer.end(requestTimerData)
+                    logger.logError(e, requestTimerData)
+                } finally {
+                    try {
+                        BotRepository.requestTimer.end(requestTimerData)
+                        context.response().end()
+                    } catch (e: Throwable) {
+                        logger.error(e)
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatConnectorCallBack.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatConnectorCallBack.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat
+
+import fr.vsct.tock.bot.connector.ConnectorCallbackBase
+
+/**
+* The BusinessChat [ConnectorCallback].
+*/
+class BusinessChatConnectorCallback(
+    applicationId: String
+) : ConnectorCallbackBase(applicationId, businessChatConnectorType)

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatConnectorProvider.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatConnectorProvider.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat
+
+import fr.vsct.tock.bot.connector.Connector
+import fr.vsct.tock.bot.connector.ConnectorConfiguration
+import fr.vsct.tock.bot.connector.ConnectorProvider
+import fr.vsct.tock.bot.connector.ConnectorType
+import fr.vsct.tock.bot.connector.ConnectorTypeConfiguration
+import fr.vsct.tock.bot.connector.ConnectorTypeConfigurationField
+import fr.vsct.tock.translator.UserInterfaceType
+
+const val BUSINESS_CHAT_CONNECTOR_TYPE_ID = "business chat"
+val businessChatConnectorType = ConnectorType(BUSINESS_CHAT_CONNECTOR_TYPE_ID, UserInterfaceType.textAndVoiceAssistant)
+
+/**
+ * Defines the configuration to be exposed on the bot admin
+ */
+internal object BusinessChatConnectorProvider : ConnectorProvider {
+
+    private const val BUSINESS_ID = "businessId"
+    override val connectorType: ConnectorType get() = businessChatConnectorType
+
+    /**
+     * Instantiates the connector according to the configuration
+     */
+    override fun connector(connectorConfiguration: ConnectorConfiguration): Connector {
+        with(connectorConfiguration) {
+            return BusinessChatConnector(path, connectorId, connectorConfiguration.parameters[BUSINESS_ID] ?: "")
+        }
+    }
+
+    /**
+     * Returns the configuration fields for the bot admin
+     */
+    override fun configuration(): ConnectorTypeConfiguration {
+        return ConnectorTypeConfiguration(
+            businessChatConnectorType,
+            listOf(
+                ConnectorTypeConfigurationField(
+                    "Business Id",
+                    BUSINESS_ID,
+                    true
+                )
+            )
+        )
+    }
+}
+
+internal class BusinessChatConnectorProviderService : ConnectorProvider by BusinessChatConnectorProvider

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatHandler.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/BusinessChatHandler.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat;
+
+import fr.vsct.tock.bot.connector.ConnectorHandler
+import fr.vsct.tock.bot.definition.ConnectorStoryHandler
+import kotlin.annotation.AnnotationTarget;
+import kotlin.annotation.MustBeDocumented;
+import kotlin.annotation.Target;
+import kotlin.reflect.KClass
+
+
+/**
+ * To specify [ConnectorStoryHandler] for BusinessChat connector.
+ * [KClass] passed as [value] of this annotation must have a primary constructor
+ * with a single not optional [StoryHandlerDefinitionBase] argument.
+ */
+@ConnectorHandler(connectorTypeId = BUSINESS_CHAT_CONNECTOR_TYPE_ID)
+@Target(AnnotationTarget.CLASS)
+@MustBeDocumented
+annotation class BusinessChatHandler(val value: KClass<out ConnectorStoryHandler<*>>)

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/CSPBusinessChatClient.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/CSPBusinessChatClient.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat
+
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorImageMessage
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorTextMessage
+
+/**
+ * This interface should be implemented to define how the Business Chat implementation from the CSP behaves
+ */
+interface CSPBusinessChatClient {
+    fun sendMessage(message: BusinessChatConnectorTextMessage)
+    fun sendAttachment(attachment: BusinessChatConnectorImageMessage)
+}

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/MessageConverter.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/MessageConverter.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat
+
+import fr.vsct.tock.bot.connector.businesschat.model.csp.message.Message
+import fr.vsct.tock.bot.connector.businesschat.model.common.MessageType
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorMessage
+import fr.vsct.tock.bot.connector.businesschat.model.input.BusinessChatConnectorTextMessage
+import fr.vsct.tock.bot.engine.BotBus
+import fr.vsct.tock.bot.engine.action.Action
+import fr.vsct.tock.bot.engine.action.SendSentence
+import fr.vsct.tock.bot.engine.event.Event
+import fr.vsct.tock.bot.engine.user.PlayerId
+import fr.vsct.tock.bot.engine.user.PlayerType
+
+object MessageConverter {
+
+    /**
+     * Converts a [BotBus] [Action] to a [BusinessChatConnectorMessage]
+     */
+    fun toMessage(action: Action): BusinessChatConnectorMessage? {
+        return if (action is SendSentence) {
+            if (action.text == null) {
+                action.messages.first() as? BusinessChatConnectorMessage
+            }
+            else BusinessChatConnectorTextMessage(
+                    sourceId = action.playerId.id,
+                    destinationId = action.recipientId.id,
+                    body = action.text.toString()
+            )
+        } else null
+    }
+
+    /**
+     * Converts a message to a [Event]
+     */
+    fun toEvent(message: Message, connectorId: String): Event? =
+        when (message.type) {
+            MessageType.text -> {
+                SendSentence(
+                    applicationId = connectorId,
+                    playerId = PlayerId(message.sourceId, PlayerType.user),
+                    recipientId = PlayerId(message.destinationId, PlayerType.bot),
+                    text = message.body
+                )
+            }
+            else -> null
+        }
+}
+

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/common/MessageType.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/common/MessageType.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat.model.common
+
+/**
+ * https://developer.apple.com/documentation/businesschatapi/messages_received/receiving_messages_from_the_business_chat_service
+ */
+enum class MessageType {
+ text,
+ interactive
+}

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/csp/BusinessChatCommonModel.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/csp/BusinessChatCommonModel.kt
@@ -1,0 +1,35 @@
+/*
+* Copyright (C) 2019 VSCT
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package fr.vsct.tock.bot.connector.businesschat.model.csp
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import fr.vsct.tock.bot.connector.businesschat.model.common.MessageType
+import java.util.UUID
+
+/**
+ * https://developer.apple.com/documentation/businesschatapi/messages_received/receiving_messages_from_the_business_chat_service
+ */
+open class BusinessChatCommonModel(
+    val id: String = UUID.randomUUID().toString(),
+    val type: MessageType,
+    @get:JsonProperty("v")
+    val version: Int = 1,
+    val intent: String? = null,
+    val group: String? = null,
+    val sourceId: String,
+    val destinationId: String
+)

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/csp/attachment/Attachment.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/csp/attachment/Attachment.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat.model.csp.attachment
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import fr.vsct.tock.bot.connector.businesschat.model.csp.BusinessChatCommonModel
+import fr.vsct.tock.bot.connector.businesschat.model.common.MessageType
+
+/**
+ * https://developer.apple.com/documentation/businesschatapi/messages_received/receiving_a_text_message_with_attachments
+ */
+class Attachment (
+        sourceId: String,
+        destinationId: String,
+        val attachments: Array<AttachmentDictionnary>
+) : BusinessChatCommonModel(sourceId = sourceId, destinationId = destinationId, type = MessageType.text) {
+        val body: String = "\uFFFc"
+}
+
+/**
+ * https://developer.apple.com/documentation/businesschatapi/attachment
+ */
+class AttachmentDictionnary(
+        val key: String,
+        val mimeType: String,
+        val name: String,
+        val owner: String,
+        @JsonProperty("signature-base64")
+        val signatureBase64: String,
+        val size: Int,
+        val url: String
+)

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/csp/message/Message.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/csp/message/Message.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat.model.csp.message
+
+import fr.vsct.tock.bot.connector.businesschat.model.csp.BusinessChatCommonModel
+import fr.vsct.tock.bot.connector.businesschat.model.common.MessageType
+
+/**
+ * https://developer.apple.com/documentation/businesschatapi/textmessage
+ */
+class Message(
+        sourceId: String,
+        destinationId: String,
+        val body: String?
+) : BusinessChatCommonModel(sourceId = sourceId, destinationId = destinationId, type = MessageType.text)

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/input/BusinessChatConnectorImageMessage.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/input/BusinessChatConnectorImageMessage.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat.model.input
+
+import fr.vsct.tock.bot.engine.BotBus
+
+/**
+ * An Image Message used on the bot side to be sent on the [BotBus]
+ */
+data class BusinessChatConnectorImageMessage (
+        override val sourceId: String,
+        override val destinationId: String,
+        val bytes: ByteArray,
+        val mimeType: String
+) : BusinessChatConnectorMessage() {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BusinessChatConnectorImageMessage
+
+        if (sourceId != other.sourceId) return false
+        if (destinationId != other.destinationId) return false
+        if (!bytes.contentEquals(other.bytes)) return false
+        if (mimeType != other.mimeType) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = sourceId.hashCode()
+        result = 31 * result + destinationId.hashCode()
+        result = 31 * result + bytes.contentHashCode()
+        result = 31 * result + mimeType.hashCode()
+        return result
+    }
+}

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/input/BusinessChatConnectorMessage.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/input/BusinessChatConnectorMessage.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat.model.input
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import fr.vsct.tock.bot.connector.ConnectorMessage
+import fr.vsct.tock.bot.connector.ConnectorType
+import fr.vsct.tock.bot.connector.businesschat.BusinessChatConnectorProvider
+import fr.vsct.tock.bot.engine.BotBus
+
+/**
+ * Defines a base [ConnectorMessage], to be sent on the [BotBus]
+ * */
+abstract class BusinessChatConnectorMessage : ConnectorMessage {
+    override val connectorType: ConnectorType @JsonIgnore get() = BusinessChatConnectorProvider.connectorType
+    abstract val sourceId: String
+    abstract val destinationId: String
+}

--- a/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/input/BusinessChatConnectorTextMessage.kt
+++ b/bot/connector-businesschat/src/main/kotlin/fr/vsct/tock/bot/connector/businesschat/model/input/BusinessChatConnectorTextMessage.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2019 VSCT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.vsct.tock.bot.connector.businesschat.model.input
+
+import fr.vsct.tock.bot.engine.BotBus
+
+/**
+ * A Text Message used on the bot side to be sent on the [BotBus]
+ */
+data class BusinessChatConnectorTextMessage(
+        override val sourceId: String,
+        override val destinationId: String,
+        val body: String?
+) : BusinessChatConnectorMessage()

--- a/bot/connector-businesschat/src/main/resources/META-INF/businesschat.svg
+++ b/bot/connector-businesschat/src/main/resources/META-INF/businesschat.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="66.145836mm"
+   height="66.145836mm"
+   viewBox="0 0 66.145836 66.145836"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   sodipodi:docname="iMessage logo.svg">
+  <title
+     id="title907">iMessage  logo</title>
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient899">
+      <stop
+         style="stop-color:#0cbd2a;stop-opacity:1"
+         offset="0"
+         id="stop895" />
+      <stop
+         style="stop-color:#5bf675;stop-opacity:1"
+         offset="1"
+         id="stop897" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient899"
+       id="linearGradient901"
+       x1="-25.272568"
+       y1="207.52057"
+       x2="-25.272568"
+       y2="152.9982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98209275,0,0,0.98209275,-1.0651782,3.7961838)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="142.01984"
+     inkscape:cy="61.975439"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:snap-object-midpoints="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:snap-intersection-paths="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="1358"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>iMessage  logo</dc:title>
+        <dc:date>02/04/2018</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Apple, Inc.</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>CMetalCore</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:source>https://upload.wikimedia.org/wikipedia/commons/8/85/IMessage_icon.png</dc:source>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(59.483067,-145.8456)">
+    <g
+       id="g963">
+      <rect
+         ry="14.567832"
+         rx="14.567832"
+         y="145.8456"
+         x="-59.483067"
+         height="66.145836"
+         width="66.145836"
+         id="rect826"
+         style="opacity:1;fill:url(#linearGradient901);fill-opacity:1;stroke:none;stroke-width:1.33634758;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path922"
+         d="m -26.410149,157.29606 a 24.278298,20.222157 0 0 0 -24.278105,20.22202 24.278298,20.222157 0 0 0 11.79463,17.31574 27.365264,20.222157 0 0 1 -4.245218,5.94228 23.85735,20.222157 0 0 0 9.86038,-3.87367 24.278298,20.222157 0 0 0 6.868313,0.83768 24.278298,20.222157 0 0 0 24.2781059,-20.22203 24.278298,20.222157 0 0 0 -24.2781059,-20.22202 z"
+         style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.56409621;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+  </g>
+</svg>

--- a/bot/connector-businesschat/src/main/resources/META-INF/services/fr.vsct.tock.bot.connector.ConnectorProvider
+++ b/bot/connector-businesschat/src/main/resources/META-INF/services/fr.vsct.tock.bot.connector.ConnectorProvider
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2019 VSCT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+fr.vsct.tock.bot.connector.businesschat.BusinessChatConnectorProviderService

--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -42,6 +42,8 @@
         <module>connector-twitter</module>
         <module>connector-whatsapp</module>
         <module>connector-teams</module>
+        <module>connector-businesschat</module>
+
         <module>storage-mongo</module>
 
         <module>toolkit-base</module>
@@ -50,6 +52,7 @@
         <module>test</module>
 
         <module>admin</module>
+
 
     </modules>
 
@@ -118,6 +121,11 @@
             <dependency>
                 <groupId>fr.vsct.tock</groupId>
                 <artifactId>tock-bot-storage-mongo</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fr.vsct.tock</groupId>
+                <artifactId>tock-bot-connector-businesschat</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>

--- a/bot/toolkit/pom.xml
+++ b/bot/toolkit/pom.xml
@@ -66,6 +66,10 @@
             <groupId>fr.vsct.tock</groupId>
             <artifactId>tock-bot-connector-teams</artifactId>
         </dependency>
+        <dependency>
+            <groupId>fr.vsct.tock</groupId>
+            <artifactId>tock-bot-connector-businesschat</artifactId>
+        </dependency>
 
         <!-- force okhttp dependencies -->
         <dependency>


### PR DESCRIPTION
The implementation of the CSPBusinessChatClient is to be made on the bot side according to the model chosen by the CSP. 