### PR TITLE
Extend mocked botBus for unit testing

### DIFF
--- a/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusMocked.kt
+++ b/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusMocked.kt
@@ -105,6 +105,22 @@ fun mockTockCommon(bus: BotBus) {
         )
     } returns null
     every { bus.changeEntityValue(any(), any<Value>()) } returns Unit
+    every {
+        bus.entityText(
+            any<Entity>()
+        )
+    } returns null
+    every {
+        bus.entityValueDetails(
+            any<Entity>()
+        )
+    } returns null
+    every {
+        bus.entityValueDetails(
+            any<String>()
+        )
+    } returns null
+    every { bus.changeEntityText(any(), any()) } returns Unit
 
     val playerId = PlayerId("user")
     every { bus.userId } returns playerId


### PR DESCRIPTION
Extend from #430 and #440.
Need some others mock functions on botBus with last version of the bot.