### PR TITLE
Visibility modifications to allow an implementation of NlpController in a custom module

### DIFF
--- a/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/BotRepository.kt
+++ b/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/BotRepository.kt
@@ -61,7 +61,7 @@ object BotRepository {
     private val botConfigurationDAO: BotApplicationConfigurationDAO get() = injector.provide()
     internal val botProviders: MutableSet<BotProvider> = mutableSetOf()
     internal val storyHandlerListeners: MutableList<StoryHandlerListener> = mutableListOf()
-    internal val nlpListeners: MutableList<NlpListener> = mutableListOf(BuiltInKeywordListener)
+    val nlpListeners: MutableList<NlpListener> = mutableListOf(BuiltInKeywordListener)
     private val nlpClient: NlpClient get() = injector.provide()
     private val nlpController: NlpController get() = injector.provide()
     private val executor: Executor get() = injector.provide()

--- a/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/ConnectorController.kt
+++ b/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/ConnectorController.kt
@@ -19,6 +19,7 @@ package fr.vsct.tock.bot.engine
 import fr.vsct.tock.bot.connector.Connector
 import fr.vsct.tock.bot.connector.ConnectorCallbackBase
 import fr.vsct.tock.bot.connector.ConnectorData
+import fr.vsct.tock.bot.connector.ConnectorType
 import fr.vsct.tock.bot.definition.BotDefinition
 import fr.vsct.tock.bot.definition.IntentAware
 import fr.vsct.tock.bot.definition.StoryHandlerDefinition
@@ -42,6 +43,8 @@ interface ConnectorController {
      * The connector used by the controller.
      */
     val connector: Connector
+
+    val connectorType: ConnectorType get() = connector.connectorType
 
     /**
      * Sends a notification to the connector.

--- a/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/TockConnectorController.kt
+++ b/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/TockConnectorController.kt
@@ -92,8 +92,6 @@ internal class TockConnectorController constructor(
     private val userLock: UserLock by injector.instance()
     private val userTimelineDAO: UserTimelineDAO by injector.instance()
 
-    val connectorType: ConnectorType get() = connector.connectorType
-
     private val serviceInstallers: MutableList<BotVerticle.ServiceInstaller> = CopyOnWriteArrayList()
 
     override fun handle(event: Event, data: ConnectorData) {

--- a/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/dialog/EntityStateValue.kt
+++ b/bot/engine/src/main/kotlin/fr/vsct/tock/bot/engine/dialog/EntityStateValue.kt
@@ -55,10 +55,10 @@ data class EntityStateValue(
     private var updated: Instant = initialUpdate
     private var loaded: Boolean = stateValueId == null
 
-    internal constructor(action: Action, entityValue: EntityValue)
+    constructor(action: Action, entityValue: EntityValue)
             : this(entityValue, mutableListOf(ArchivedEntityValue(entityValue, action)))
 
-    internal constructor(entity: Entity, value: Value) : this(EntityValue(entity, value))
+    constructor(entity: Entity, value: Value) : this(EntityValue(entity, value))
 
     init {
         if (value != null) {


### PR DESCRIPTION
I'm currently coding a new implementation of the interface NlpController in a custom module.
Unfortunately, I can't access some properties or constructors because their visibility is internal to the module tock-bot-engine.

This pull request is to allow an implementation of NlpController outside tock-bot-engine.