### PR TITLE
Module for Dialogflow integration as NLP in a Tock bot

### DIFF
--- a/nlp/api/client/src/main/kotlin/fr/vsct/tock/nlp/api/client/model/NlpResult.kt
+++ b/nlp/api/client/src/main/kotlin/fr/vsct/tock/nlp/api/client/model/NlpResult.kt
@@ -58,7 +58,11 @@ data class NlpResult(
     /**
      * Other intents with significant probabilities.
      */
-    val otherIntentsProbabilities: Map<String, Double> = emptyMap()
+    val otherIntentsProbabilities: Map<String, Double> = emptyMap(),
+    /**
+     * The static text response possibly returned for the [NlpQuery]
+     */
+    val staticResponse: String? = null
 ) {
 
     fun firstValue(role: String): NlpEntityValue? = entities.firstOrNull { it.entity.role == role }

--- a/nlp/dialogflow/README.md
+++ b/nlp/dialogflow/README.md
@@ -1,0 +1,21 @@
+## Usage
+
+To use Dialogflow as NLP in a Tock bot :
+- Add the module dependency to your pom.xml
+
+        <dependency>
+            <groupId>fr.vsct.tock</groupId>
+            <artifactId>tock-nlp-dialogflow</artifactId>
+            <version>${tock}</version>
+        </dependency>
+        
+- Install your bot by adding a module with the following configuration :
+
+```
+    bind<NlpClient>(overrides = true) with singleton { TockDialogflowNlpClient() }
+    bind<NlpController>(overrides = true) with singleton { DialogflowNlp() }
+```    
+    
+- Set the environment variable `dialogflow_project_id` with your Dialogflow project id
+
+- Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` with the file path of the JSON file that contains your service account key

--- a/nlp/dialogflow/pom.xml
+++ b/nlp/dialogflow/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fr.vsct.tock</groupId>
+        <artifactId>tock-nlp</artifactId>
+        <version>19.3.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>tock-nlp-dialogflow</artifactId>
+    <name>Tock NLP Dialogflow</name>
+    <description>Client interface for Tock NLP API</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.vsct.tock</groupId>
+            <artifactId>tock-bot-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-dialogflow</artifactId>
+            <version>0.87.0-alpha</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-oauth2-http</artifactId>
+            <version>0.15.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.microutils</groupId>
+            <artifactId>kotlin-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowNlp.kt
+++ b/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowNlp.kt
@@ -1,0 +1,288 @@
+package fr.vsct.tock.nlp.dialogflow
+
+import fr.vsct.tock.bot.definition.BotDefinition
+import fr.vsct.tock.bot.definition.Intent
+import fr.vsct.tock.bot.engine.BotRepository
+import fr.vsct.tock.bot.engine.ConnectorController
+import fr.vsct.tock.bot.engine.action.SendSentence
+import fr.vsct.tock.bot.engine.dialog.Dialog
+import fr.vsct.tock.bot.engine.dialog.EntityStateValue
+import fr.vsct.tock.bot.engine.dialog.EntityValue
+import fr.vsct.tock.bot.engine.nlp.NlpCallStats
+import fr.vsct.tock.bot.engine.nlp.NlpController
+import fr.vsct.tock.bot.engine.user.UserTimeline
+import fr.vsct.tock.nlp.api.client.NlpClient
+import fr.vsct.tock.nlp.api.client.model.*
+import fr.vsct.tock.nlp.api.client.model.dump.ApplicationDump
+import fr.vsct.tock.nlp.api.client.model.dump.IntentDefinition
+import fr.vsct.tock.nlp.api.client.model.dump.SentencesDump
+import fr.vsct.tock.nlp.api.client.model.monitoring.MarkAsUnknownQuery
+import fr.vsct.tock.shared.*
+import mu.KotlinLogging
+import java.io.InputStream
+import java.time.ZonedDateTime
+
+/**
+ * [NlpController] Dialogflow implementation.
+ */
+class DialogflowNlp : NlpController {
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+
+    private val nlpClient: NlpClient get() = injector.provide()
+    private val executor: Executor get() = injector.provide()
+
+    private class SentenceParser(
+        val nlpClient: NlpClient,
+        val sentence: SendSentence,
+        val userTimeline: UserTimeline,
+        val dialog: Dialog,
+        val connector: ConnectorController,
+        val botDefinition: BotDefinition
+    ) {
+
+        fun parse() {
+            logger.debug { "Parse sentence : $sentence" }
+
+            findKeyword(sentence.stringText)?.apply {
+                dialog.state.currentIntent = this
+                return
+            }
+
+            toNlpQuery().let { query ->
+                try {
+                    val result = sentence.precomputedNlp ?: parse(query)
+
+                    result?.let { nlpResult ->
+
+                        listenNlpSuccessCall(query, nlpResult)
+                        val intent = findIntent(userTimeline, dialog, sentence, nlpResult)
+
+                        val customEntityEvaluations: MutableList<EntityValue> = mutableListOf()
+                        BotRepository.forEachNlpListener {
+                            customEntityEvaluations.addAll(
+                                try {
+                                    it.evaluateEntities(userTimeline, dialog, sentence, nlpResult)
+                                } catch (e: Exception) {
+                                    logger.error(e)
+                                    emptyList<EntityValue>()
+                                }
+                            )
+                        }
+
+                        val entityEvaluations = customEntityEvaluations +
+                                nlpResult.entities
+                                    .asSequence()
+                                    .filter { e -> customEntityEvaluations.none { it.entity == e.entity } }
+                                    .map { EntityValue(nlpResult, it) }
+                        sentence.state.entityValues.addAll(entityEvaluations)
+
+                        dialog.apply {
+                            state.currentIntent = intent
+                            nlpResult.staticResponse?.let {
+                                // Add the static response from Dialogflow to the state context as a message
+                                // Thus, this message can be used later in a story
+                                state.setContextValue("message", nlpResult.staticResponse)
+                            }
+
+                            entityEvaluations
+                                .map {
+                                    state.entityValues[it.entity.role] = EntityStateValue(sentence, it)
+                            }
+
+                            sentence.nlpStats = NlpCallStats(
+                                userTimeline.userPreferences.locale,
+                                intent,
+                                entityEvaluations,
+                                entityEvaluations,
+                                query,
+                                nlpResult
+                            )
+                        }
+                    } ?: listenNlpErrorCall(query, null)
+                } catch (t: Throwable) {
+                    logger.error(t)
+                    listenNlpErrorCall(query, t)
+                }
+            }
+        }
+
+        private fun findIntent(
+            userTimeline: UserTimeline,
+            dialog: Dialog,
+            sentence: SendSentence,
+            nlpResult: NlpResult
+        ): Intent {
+            var i: Intent? = null
+            BotRepository.forEachNlpListener {
+                if (i == null) {
+                    i = try {
+                        it.findIntent(userTimeline, dialog, sentence, nlpResult)?.wrappedIntent()
+                    } catch (e: Exception) {
+                        logger.error(e)
+                        null
+                    }
+                }
+            }
+
+            return i ?: botDefinition.findIntent(nlpResult.intent)
+        }
+
+        private fun findKeyword(sentence: String?): Intent? {
+            return if (sentence != null) {
+                var i: Intent? = null
+                BotRepository.forEachNlpListener {
+                    if (i == null) {
+                        i = try {
+                            it.handleKeyword(sentence)
+                        } catch (e: Exception) {
+                            logger.error(e)
+                            null
+                        }
+                    }
+
+                }
+                i
+            } else {
+                null
+            }
+        }
+
+        private fun listenNlpSuccessCall(query: NlpQuery, result: NlpResult) {
+            BotRepository.forEachNlpListener {
+                try {
+                    it.success(query, result)
+                } catch (e: Exception) {
+                    logger.error(e)
+                }
+            }
+        }
+
+        private fun listenNlpErrorCall(query: NlpQuery, throwable: Throwable?) {
+            BotRepository.forEachNlpListener {
+                try {
+                    it.error(query, throwable)
+                } catch (e: Exception) {
+                    logger.error(e)
+                }
+            }
+        }
+
+        private fun toQueryContext(): NlpQueryContext {
+            val test = userTimeline.userPreferences.test
+            return NlpQueryContext(
+                userTimeline.userPreferences.locale,
+                sentence.playerId.id,
+                dialog.id.toString(),
+                connector.connectorType.toString(),
+                referenceDate = dialog.state.nextActionState?.referenceDate ?: ZonedDateTime.now(defaultZoneId),
+                referenceTimezone = dialog.state.nextActionState?.referenceTimezone ?: defaultZoneId,
+                test = test,
+                registerQuery = !test && !userTimeline.userState.botDisabled
+            )
+        }
+
+        private fun toNlpQuery(): NlpQuery {
+            return NlpQuery(
+                listOf(sentence.stringText ?: ""),
+                botDefinition.namespace,
+                botDefinition.nlpModelName,
+                toQueryContext(),
+                NlpQueryState(
+                    dialog.state.nextActionState?.states
+                            ?: listOfNotNull(dialog.currentStory?.definition?.mainIntent()?.name).toSet()
+                )
+            )
+        }
+
+        private fun parse(request: NlpQuery): NlpResult? {
+            logger.debug { "Sending sentence '${sentence.stringText}' to NLP" }
+            val intentsQualifiers = dialog.state.nextActionState?.intentsQualifiers
+            val useQualifiers = intentsQualifiers != null && intentsQualifiers.isNotEmpty()
+            val result = if (!useQualifiers) {
+                nlpClient.parse(request)
+            } else {
+                nlpClient.parse(
+                    request.copy(intentsSubset = intentsQualifiers!!.asSequence().map {
+                        it.copy(
+                            intent = it.intent.withNamespace(
+                                request.namespace
+                            )
+                        )
+                    }.toSet())
+                )
+            }
+            if (result != null && useQualifiers) {
+                //force intents qualifiers if unknown answer
+                if (intentsQualifiers!!.none { it.intent == result.intent }) {
+                    return result.copy(
+                        intent = intentsQualifiers.maxBy { it.modifier }?.intent ?: intentsQualifiers.first().intent
+                    ).also {
+                        logger.warn { "${result.intent} not in intents qualifier $intentsQualifiers - use $it" }
+                    }
+                }
+            }
+            return result
+        }
+
+    }
+
+    override fun parseSentence(
+        sentence: SendSentence,
+        userTimeline: UserTimeline,
+        dialog: Dialog,
+        connector: ConnectorController,
+        botDefinition: BotDefinition
+    ) {
+        SentenceParser(
+            nlpClient,
+            sentence,
+            userTimeline,
+            dialog,
+            connector,
+            botDefinition
+        ).parse()
+    }
+
+    override fun markAsUnknown(
+        sentence: SendSentence,
+        userTimeline: UserTimeline,
+        botDefinition: BotDefinition
+    ) {
+        if (sentence.stringText != null) {
+            executor.executeBlocking {
+                nlpClient.markAsUnknown(
+                    MarkAsUnknownQuery(
+                        botDefinition.namespace,
+                        botDefinition.nlpModelName,
+                        userTimeline.userPreferences.locale,
+                        sentence.stringText!!
+                    )
+                )
+            }
+        }
+    }
+
+    override fun getIntentsByNamespaceAndName(namespace: String, name: String): List<IntentDefinition>? =
+        nlpClient.getIntentsByNamespaceAndName(namespace, name) ?: emptyList()
+
+    override fun importNlpDump(stream: InputStream): Boolean =
+        nlpClient.importNlpDump(stream)
+
+    override fun importNlpPlainDump(dump: ApplicationDump): Boolean =
+        nlpClient.importNlpPlainDump(dump)
+
+    override fun importNlpPlainSentencesDump(dump: SentencesDump): Boolean =
+        nlpClient.importNlpPlainSentencesDump(dump)
+
+    override fun importNlpSentencesDump(stream: InputStream): Boolean =
+        nlpClient.importNlpSentencesDump(stream)
+
+    override fun waitAvailability(timeToWaitInMs: Long) {
+        val s = System.currentTimeMillis()
+        while (!nlpClient.healthcheck() && System.currentTimeMillis() - s < timeToWaitInMs) {
+        }
+    }
+}

--- a/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowService.kt
+++ b/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowService.kt
@@ -1,0 +1,60 @@
+package fr.vsct.tock.nlp.dialogflow
+
+import com.google.cloud.dialogflow.v2.*
+import mu.KotlinLogging
+
+
+object DialogflowService {
+
+    private val logger = KotlinLogging.logger {}
+
+    /**
+     * Returns the result of detect intent with text as input.
+     *
+     * Using the same `session_id` between requests allows continuation of the conversation.
+     *
+     * @param projectId    Project/Agent Id.
+     * @param text         The text intent to be detected based on what a user says.
+     * @param sessionId    Identifier of the DetectIntent session.
+     * @param languageCode Language code of the query.
+     * @return The QueryResult for the input text.
+     */
+    fun detectIntentText(
+        projectId: String,
+        text: String,
+        sessionId: String,
+        languageCode: String) : QueryResult? {
+
+        SessionsClient.create().use {
+            // Set the session name using the sessionId (UUID) and projectID (my-project-id)
+            val session = SessionName.of(projectId, sessionId)
+            logger.debug("Session Path: $session")
+
+            // Set the text (hello) and language code (en-US) for the query
+            TextInput.newBuilder().setText(text).setLanguageCode(languageCode)
+                .apply {
+                    QueryInput.newBuilder().setText(this).build().apply {
+                        it.detectIntent(session, this).apply {
+                            return this.queryResult.also {
+                                logger.debug("Query Text: '${it.queryText}'")
+                                logger.debug("Detected Intent: ${it.intent.displayName} (confidence: ${it.intentDetectionConfidence})")
+                            }
+                        }
+                    }
+                }
+        }
+        return null
+    }
+
+    /**
+     * Retrieves the [Agent] of the given [projectId].
+     */
+    fun getAgent(projectId: String): Agent? {
+        AgentsClient.create().use {
+            val parent: ProjectName = ProjectName.of(projectId)
+            return it.getAgent(parent)
+        }
+    }
+
+}
+

--- a/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowTockMapper.kt
+++ b/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowTockMapper.kt
@@ -1,0 +1,76 @@
+package fr.vsct.tock.nlp.dialogflow
+
+import com.google.cloud.dialogflow.v2.QueryResult
+import com.google.protobuf.Value
+import fr.vsct.tock.nlp.api.client.model.Entity
+import fr.vsct.tock.nlp.api.client.model.EntityType
+import fr.vsct.tock.nlp.api.client.model.NlpEntityValue
+import fr.vsct.tock.nlp.api.client.model.NlpResult
+import fr.vsct.tock.nlp.entity.NumberValue
+import fr.vsct.tock.nlp.entity.StringValue
+import java.util.*
+
+class DialogflowTockMapper {
+
+    /**
+     * Returns a Tock entity from a Dialogflow Value.
+     */
+    private fun dialogflowEntityToTockEntity(
+        parameterName: String,
+        namespace: String
+    ): Entity? {
+        return Entity(EntityType("$namespace:$parameterName"), parameterName)
+    }
+
+    /**
+     * Returns a Tock [NlpEntityValue] from a Dialogflow Value.
+     */
+    private fun dialogflowEntityToTockEntityValue(
+        parameter: Map.Entry<String, Value>,
+        namespace: String
+    ): NlpEntityValue? {
+        val entity = dialogflowEntityToTockEntity(parameter.key, namespace)!!
+        val value: fr.vsct.tock.nlp.entity.Value? = when (parameter.value.kindCase) {
+            Value.KindCase.NUMBER_VALUE -> NumberValue(parameter.value.numberValue)
+            Value.KindCase.STRING_VALUE -> if (parameter.value.stringValue.trim().isEmpty()) null else StringValue(parameter.value.stringValue)
+            Value.KindCase.BOOL_VALUE -> StringValue(parameter.value.boolValue.toString())
+            else -> null
+        }
+
+        if (value.toString().trim().isEmpty() || value == null) {
+            return null
+        }
+
+        return NlpEntityValue(
+            0,
+            0,
+            entity,
+            value
+        )
+    }
+
+    fun toNlpResult(queryResult: QueryResult, namespace: String): NlpResult {
+        val intent = queryResult.intent.displayName
+
+        val parameters = queryResult.parameters?.fieldsMap?.filter {
+            !it.value.hasStructValue() && !it.value.hasListValue() && dialogflowEntityToTockEntity(it.key, namespace) != null
+        } ?: emptyMap()
+        val entityValues =
+            parameters.map {
+                dialogflowEntityToTockEntityValue(it, namespace)
+            }
+
+        return NlpResult(
+            intent,
+            namespace,
+            Locale(queryResult.languageCode),
+            entityValues.filterNotNull(),
+            emptyList(),
+            queryResult.intentDetectionConfidence.toDouble(),
+            1.0,
+            queryResult.queryText,
+            staticResponse = queryResult.fulfillmentText.takeIf { it.trim().isNotEmpty() }
+        )
+    }
+
+}

--- a/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/TockDialogflowNlpClient.kt
+++ b/nlp/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/TockDialogflowNlpClient.kt
@@ -1,0 +1,54 @@
+package fr.vsct.tock.nlp.dialogflow
+
+import fr.vsct.tock.nlp.api.client.NlpClient
+import fr.vsct.tock.nlp.api.client.model.NlpQuery
+import fr.vsct.tock.nlp.api.client.model.NlpResult
+import fr.vsct.tock.nlp.api.client.model.dump.ApplicationDefinition
+import fr.vsct.tock.nlp.api.client.model.dump.ApplicationDump
+import fr.vsct.tock.nlp.api.client.model.dump.IntentDefinition
+import fr.vsct.tock.nlp.api.client.model.dump.SentencesDump
+import fr.vsct.tock.nlp.api.client.model.evaluation.EntityEvaluationQuery
+import fr.vsct.tock.nlp.api.client.model.evaluation.EntityEvaluationResult
+import fr.vsct.tock.nlp.api.client.model.merge.ValuesMergeQuery
+import fr.vsct.tock.nlp.api.client.model.merge.ValuesMergeResult
+import fr.vsct.tock.nlp.api.client.model.monitoring.MarkAsUnknownQuery
+import fr.vsct.tock.shared.property
+import java.io.InputStream
+import java.util.*
+
+
+class TockDialogflowNlpClient : NlpClient {
+
+    private val projectId = property("dialogflow_project_id", "please set a google project id")
+
+    override fun parse(query: NlpQuery): NlpResult? {
+        return DialogflowService.detectIntentText(projectId, query.queries.firstOrNull()?: "", query.context.dialogId, query.context.language.toString())?.let {
+            DialogflowTockMapper().toNlpResult(it, query.namespace)
+        }
+    }
+
+    override fun healthcheck(): Boolean {
+        return DialogflowService.getAgent(projectId) != null
+    }
+
+    override fun evaluateEntities(query: EntityEvaluationQuery): EntityEvaluationResult? = null
+
+    override fun mergeValues(query: ValuesMergeQuery): ValuesMergeResult? = null
+
+    override fun markAsUnknown(query: MarkAsUnknownQuery) = Unit
+
+    override fun getIntentsByNamespaceAndName(namespace: String, name: String): List<IntentDefinition>? = null
+
+    override fun getApplicationByNamespaceAndName(namespace: String, name: String): ApplicationDefinition? = null
+
+    override fun createApplication(namespace: String, name: String, locale: Locale): ApplicationDefinition? = null
+
+    override fun importNlpDump(stream: InputStream): Boolean = false
+
+    override fun importNlpPlainDump(dump: ApplicationDump): Boolean = false
+
+    override fun importNlpSentencesDump(stream: InputStream): Boolean = false
+
+    override fun importNlpPlainSentencesDump(dump: SentencesDump): Boolean = false
+}
+

--- a/nlp/dialogflow/src/test/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowTockMapperTest.kt
+++ b/nlp/dialogflow/src/test/kotlin/fr/vsct/tock/nlp/dialogflow/DialogflowTockMapperTest.kt
@@ -1,0 +1,45 @@
+package fr.vsct.tock.nlp.dialogflow
+
+import com.google.cloud.dialogflow.v2.QueryResult
+import com.google.protobuf.ListValue
+import com.google.protobuf.Struct
+import com.google.protobuf.Value
+import fr.vsct.tock.nlp.entity.NumberValue
+import fr.vsct.tock.nlp.entity.StringValue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class DialogflowTockMapperTest {
+
+    @Test
+    fun `nlp result mapping`() {
+        val namespace = "app"
+        val intentName = "test_intent"
+        val queryText = "I test my intent"
+        val intentProbability = 0.8f
+        val numberEntityName = "number_entity"
+
+        val queryResultBuilder = QueryResult.newBuilder()
+        queryResultBuilder.intentBuilder.setDisplayName(intentName).build()
+        queryResultBuilder.queryText = queryText
+        queryResultBuilder.intentDetectionConfidence = intentProbability
+        queryResultBuilder.parametersBuilder.putFields(numberEntityName, Value.newBuilder().setNumberValue(666.0).build())
+        queryResultBuilder.parametersBuilder.putFields("text_entity", Value.newBuilder().setStringValue("text_value").build())
+        queryResultBuilder.parametersBuilder.putFields("boolean_entity", Value.newBuilder().setBoolValue(true).build())
+        queryResultBuilder.parametersBuilder.putFields("struct_entity", Value.newBuilder().setStructValue(Struct.newBuilder()).build())
+        queryResultBuilder.parametersBuilder.putFields("list_entity", Value.newBuilder().setListValue(ListValue.newBuilder()).build())
+
+
+        val nlpResult = DialogflowTockMapper().toNlpResult(queryResultBuilder.build(), namespace)
+        assertEquals(intentName, nlpResult.intent)
+        assertEquals(namespace, nlpResult.intentNamespace)
+        assertEquals(queryText, nlpResult.retainedQuery)
+        assertEquals(intentProbability.toDouble(), nlpResult.intentProbability)
+        assertEquals(nlpResult.entities.size, 3)
+        assertEquals(nlpResult.entities[0].entity.entityType.name, "$namespace:$numberEntityName")
+        assertEquals(nlpResult.entities[0].entity.role, numberEntityName)
+        assertEquals(nlpResult.entities[0].value, NumberValue(666.0))
+        assertEquals(nlpResult.entities[1].value, StringValue("text_value"))
+        assertEquals(nlpResult.entities[2].value, StringValue("true"))
+    }
+}

--- a/nlp/pom.xml
+++ b/nlp/pom.xml
@@ -43,6 +43,7 @@
         <module>api</module>
 
         <module>integration-tests</module>
+        <module>dialogflow</module>
     </modules>
 
     <dependencyManagement>
@@ -99,6 +100,11 @@
             </dependency>
             <dependency>
                 <groupId>fr.vsct.tock</groupId>
+                <artifactId>tock-nlp-model-stanford</artifactId>
+                <version>19.3.0</version>
+            </dependency>
+            <dependency>
+                <groupId>fr.vsct.tock</groupId>
                 <artifactId>tock-nlp-model-storage-mongo</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -131,6 +137,11 @@
             <dependency>
                 <groupId>fr.vsct.tock</groupId>
                 <artifactId>tock-nlp-front-ioc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>fr.vsct.tock</groupId>
+                <artifactId>tock-nlp-dialogflow</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Usage

To use Dialogflow as NLP in a Tock bot :
- Add the module dependency to your pom.xml

        <dependency>
            <groupId>fr.vsct.tock</groupId>
            <artifactId>tock-nlp-dialogflow</artifactId>
            <version>${tock}</version>
        </dependency>
        
- Install your bot by adding a module with the following configuration :

```
    bind<NlpClient>(overrides = true) with singleton { TockDialogflowNlpClient() }
    bind<NlpController>(overrides = true) with singleton { DialogflowNlp() }
```    
    
- Set the environment variable `dialogflow_project_id` with your Dialogflow project id

- Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` with the file path of the JSON file that contains your service account key