### PR TITLE
Fix : correct the 404 error when updating i18n from the web admin

### DIFF
--- a/bot/admin/web/src/app/bot/bot-service.ts
+++ b/bot/admin/web/src/app/bot/bot-service.ts
@@ -67,7 +67,7 @@ export class BotService {
   }
 
   saveI18nLabel(label: I18nLabel): Observable<boolean> {
-    return this.rest.post("/i18n/save", label);
+    return this.rest.post("/i18n/saveTestPlan", label);
   }
 
   createI18nLabel(request: CreateI18nLabelRequest): Observable<I18nLabel> {


### PR DESCRIPTION
Dans le commit https://github.com/voyages-sncf-technologies/tock/commit/dbce93b9cdbf03d011f67a216275c6354ef75f11 le endpoint du service permettant de sauvegarder les traductions i18n a été renommé de `blockingJsonPost("/i18n/save", botUser)` vers `blockingJsonPost("/i18n/saveTestPlan", botUser)`.

Cependant l'url n'a pas été modifiée dans l'admin web et renvoi donc actuellement une 404.

Le nouveau nom du endpoint est peut être a revoir, mais en attendant je propose de rectifier l'url dans le front de l'admin web.