### PR TITLE
Testing simplification

### DIFF
--- a/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusAsserts.kt
+++ b/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusAsserts.kt
@@ -1,9 +1,72 @@
 package fr.vsct.tock.bot.test
 
+import ch.tutteli.atrium.api.cc.en_GB.contains
+import ch.tutteli.atrium.api.cc.en_GB.property
 import ch.tutteli.atrium.api.cc.en_GB.returnValueOf
 import ch.tutteli.atrium.api.cc.en_GB.toBe
 import ch.tutteli.atrium.creating.Assert
+import ch.tutteli.atrium.domain.builders.AssertImpl
+import ch.tutteli.atrium.domain.creating.any.typetransformation.AnyTypeTransformation
+import ch.tutteli.atrium.reporting.RawString
+import ch.tutteli.atrium.reporting.translating.Untranslatable
+import ch.tutteli.atrium.verbs.expect
+import fr.vsct.tock.bot.engine.action.SendChoice
+import fr.vsct.tock.bot.engine.action.SendSentence
+import fr.vsct.tock.bot.engine.message.GenericElement
+import fr.vsct.tock.bot.engine.message.GenericMessage
 
-fun Assert<BotBusMockLog>.toBeSimpleTextMessage(expectedText : String)
-        = returnValueOf(BotBusMockLog::text).toBe(expectedText)
+fun Assert<BotBusMockLog>.toBeSimpleTextMessage(expectedText: String) =
+    returnValueOf(BotBusMockLog::text).toBe(expectedText)
+
+fun Assert<BotBusMockLog>.asGenericMessage(assertionCreator: Assert<GenericMessage>.() -> Unit) {
+    val parameterObject = AnyTypeTransformation.ParameterObject(
+        Untranslatable("is a"),
+        RawString.create(GenericMessage::class.simpleName!!),
+        this,
+        assertionCreator,
+        Untranslatable("cannot be converted to generic message : is not a send sentence")
+    )
+    AssertImpl.any.typeTransformation.transform(
+        parameterObject, { it.action is SendSentence && it.genericMessage() != null }, { it.genericMessage()!! },
+        AssertImpl.any.typeTransformation.failureHandlers.newExplanatory()
+    )
+}
+
+fun Assert<GenericMessage>.toHaveGlobalText(expectedText: String, textName: String = "text") =
+    property(GenericMessage::texts).addAssertionsCreatedBy {
+        returnValueOf(Map<String, String>::get, textName).toBe(expectedText)
+    }
+
+fun Assert<GenericMessage>.toHaveGlobalChoices(expectedChoice  : String, vararg otherExpectedChoices: String) =
+    property(GenericMessage::choices).addAssertionsCreatedBy {
+        expect(subject.map { choice ->
+            choice.parameters[SendChoice.TITLE_PARAMETER]
+        }).contains(expectedChoice, *otherExpectedChoices)
+    }
+
+fun Assert<GenericMessage>.toHaveElement(index: Int, assertionCreator: Assert<GenericElement>.() -> Unit) =
+    property(GenericMessage::subElements).addAssertionsCreatedBy {
+        returnValueOf(List<GenericElement>::get, index) {
+            addAssertionsCreatedBy(assertionCreator)
+        }
+    }
+
+fun Assert<GenericElement>.toHaveText(expectedText: String, textName: String) =
+    property(GenericElement::texts).addAssertionsCreatedBy {
+        returnValueOf(Map<String, String>::get, textName).toBe(expectedText)
+    }
+
+fun Assert<GenericElement>.toHaveTitle(expectedTitle: String) =
+    toHaveText(expectedTitle, "title")
+
+fun Assert<GenericElement>.toHaveSubtitle(expectedSubtitle: String) =
+    toHaveText(expectedSubtitle, "subtitle")
+
+fun Assert<GenericElement>.toHaveChoices(expectedChoice  : String, vararg otherExpectedChoices: String) =
+    property(GenericElement::choices).addAssertionsCreatedBy {
+        expect(subject.mapNotNull { choice ->
+            choice.parameters[SendChoice.TITLE_PARAMETER]
+        }).contains(expectedChoice, *otherExpectedChoices)
+    }
+
 

--- a/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusMessengerAsserts.kt
+++ b/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusMessengerAsserts.kt
@@ -1,8 +1,6 @@
 package fr.vsct.tock.bot.test
 
 
-import ch.tutteli.atrium.api.cc.en_GB.get
-import ch.tutteli.atrium.api.cc.en_GB.hasSize
 import ch.tutteli.atrium.api.cc.en_GB.isA
 import ch.tutteli.atrium.api.cc.en_GB.notToBeNull
 import ch.tutteli.atrium.api.cc.en_GB.property
@@ -65,7 +63,7 @@ fun Assert<AttachmentMessage>.withButtonAttachment(text: String, buttonTitles: L
 fun Assert<AttachmentMessage>.withGenericTemplateElement(
     index: Int,
     expectedTitle: String,
-    subtitle: String?,
+    subtitle: String? = null,
     buttonTitles: List<String>
 ) =
     property(AttachmentMessage::attachment)

--- a/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusMockLog.kt
+++ b/bot/test-base/src/main/kotlin/fr/vsct/tock/bot/test/BotBusMockLog.kt
@@ -19,7 +19,10 @@ package fr.vsct.tock.bot.test
 import fr.vsct.tock.bot.connector.ConnectorMessage
 import fr.vsct.tock.bot.connector.ConnectorType
 import fr.vsct.tock.bot.engine.action.Action
+import fr.vsct.tock.bot.engine.action.SendChoice
 import fr.vsct.tock.bot.engine.action.SendSentence
+import fr.vsct.tock.bot.engine.message.Choice
+import fr.vsct.tock.bot.engine.message.GenericMessage
 import kotlin.test.assertEquals
 
 /**
@@ -66,5 +69,31 @@ data class BotBusMockLog(
      * Assert that log contains specified message.
      */
     infix fun assert(message: ConnectorMessage) = assertMessage(message)
+
+    /**
+     * Convert current BotBusLog action first message to a generic message
+     */
+    fun genericMessage(): GenericMessage? = (action as? SendSentence)
+        ?.messages
+        ?.let { if (it.size == 1) it.first() else null }
+        ?.toGenericMessage()
+
+    /**
+     * Retrieve choice member with expected title belonging to element with specified index
+     */
+    fun elementChoice(elementIndex: Int, title: String): Choice? =
+        genericMessage()?.subElements?.get(elementIndex)
+            ?.choices
+            ?.find(hasTitle(title))
+
+    /**
+     * Retrieve choice member of main part of generic message with expected title
+     */
+    fun choice(title: String): Choice? =
+        genericMessage()?.choices
+            ?.find(hasTitle(title))
+
+    private fun hasTitle(title: String): (Choice) -> Boolean =
+        { it.parameters[SendChoice.TITLE_PARAMETER] == title }
 
 }


### PR DESCRIPTION
Tock junit extension send methods now return created BotBusMock so we can use it in the following conversation, functions has been added to BotBusMockLog to convert to generic message and retrieve choice element. At last fluent assertions have be added on generic message conversions of connector messages.

Exemple of conversation test :

```
        val searchBus = ext.sendMessage("Next train for Paris from Lyon") {
            expect(firstBusAnswer).toBeSimpleTextMessage("Here are the next departures from Lyon to Paris" )
            expect(secondBusAnswer).asGenericMessage {
                toHaveElement(0) {
                    toHaveTitle("Lyon 9:19 -> Paris 11:36")
                    toHaveSubtitle("2nd class from 33.00 €")
                    toHaveChoices("Book", "More information")
                }
            }
        }

        ext.sendMessage(message = searchBus.secondBusAnswer.elementChoice(0, "Book")!!) {
            expect(firstBusAnswer).asGenericMessage {
                toHaveGlobalTitle("Perfect, you can now pay")
                toHaveGlobalChoices("Pay", "Take an option")
            }
        }
```