### PR TITLE
Disable Dialogflow healthcheck

### DIFF
--- a/bot/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/TockDialogflowNlpClient.kt
+++ b/bot/dialogflow/src/main/kotlin/fr/vsct/tock/nlp/dialogflow/TockDialogflowNlpClient.kt
@@ -32,7 +32,7 @@ internal class TockDialogflowNlpClient : NlpClient {
     }
 
     override fun healthcheck(): Boolean {
-        return DialogflowService.getAgent(projectId) != null
+        return true
     }
 
     override fun evaluateEntities(query: EntityEvaluationQuery): EntityEvaluationResult? = null


### PR DESCRIPTION
Not reliable.
Dialogflow will stop responding after too many calls in a short period of time (for example, after a call to the health check every minute for 30 minutes).